### PR TITLE
fix: screenshot quality, timestamped filenames, bump 0.9.1-beta

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -11,7 +11,7 @@
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.0-beta</string>
+    <string>0.9.1-beta</string>
     <key>CFBundleExecutable</key>
     <string>Shotnix</string>
     <key>CFBundlePackageType</key>

--- a/Sources/Shotnix/Annotation/AnnotationWindowController.swift
+++ b/Sources/Shotnix/Annotation/AnnotationWindowController.swift
@@ -74,7 +74,7 @@ final class AnnotationWindowController: NSWindowController {
     private func save() {
         canvas.commitTextField()
         let flat = canvas.flatten()
-        ImageExporter.saveWithPanel(image: flat, suggestedName: "screenshot")
+        ImageExporter.saveWithPanel(image: flat, suggestedName: ImageExporter.timestampedName)
     }
 
     private func copyToClipboard() {

--- a/Sources/Shotnix/App/PreferencesWindowController.swift
+++ b/Sources/Shotnix/App/PreferencesWindowController.swift
@@ -426,7 +426,7 @@ final class PreferencesWindowController: NSObject, NSToolbarDelegate, NSWindowDe
         y -= 34
 
         // Version
-        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.9.0-beta"
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.9.1-beta"
         let versionLabel = NSTextField(labelWithString: "Version \(version)")
         versionLabel.font = .systemFont(ofSize: 12)
         versionLabel.textColor = .secondaryLabelColor
@@ -458,6 +458,14 @@ final class PreferencesWindowController: NSObject, NSToolbarDelegate, NSWindowDe
         textView.textContainerInset = NSSize(width: 10, height: 10)
         textView.font = .systemFont(ofSize: 12)
         textView.string = """
+        Version 0.9.1-beta
+        \u{2022} Pixel-perfect screenshot quality (fixed CoreGraphics resampling blur)
+        \u{2022} Correct DPI metadata for Retina captures (144 DPI)
+        \u{2022} Timestamped filenames — "Shotnix 2026-04-12 at 10.30.48"
+        \u{2022} Auto-disable conflicting macOS screenshot shortcuts on first launch
+        \u{2022} Fixed windows not coming to front (preferences, history, annotation)
+        \u{2022} Crash guards for empty screen arrays and async cleanup races
+
         Version 0.9.0-beta
         \u{2022} Area, window, and fullscreen capture
         \u{2022} Scrolling capture for long content

--- a/Sources/Shotnix/Capture/AreaSelectionWindow.swift
+++ b/Sources/Shotnix/Capture/AreaSelectionWindow.swift
@@ -56,7 +56,8 @@ final class AreaSelectionWindow: NSObject {
     }
 
     private func focusFirstOverlay() {
-        guard let first = overlays.first, !overlays.isEmpty else { return }
+        guard !overlays.isEmpty, let first = overlays.first else { return }
+        guard first.isVisible else { return }
         NSApp.activate(ignoringOtherApps: true)
         first.makeKeyAndOrderFront(nil)
         first.makeMain()

--- a/Sources/Shotnix/Capture/CaptureEngine.swift
+++ b/Sources/Shotnix/Capture/CaptureEngine.swift
@@ -51,6 +51,7 @@ final class CaptureEngine {
             PermissionsManager.showPermissionDeniedAlert(); return
         }
         let screens = NSScreen.screens
+        guard !screens.isEmpty else { return }
         // Capture the main (key) screen
         let screen = NSScreen.main ?? screens[0]
         let rect = screen.frame

--- a/Sources/Shotnix/Capture/CaptureEngine.swift
+++ b/Sources/Shotnix/Capture/CaptureEngine.swift
@@ -174,7 +174,7 @@ final class CaptureEngine {
             config.captureResolution = .best
             config.colorSpaceName = CGColorSpace.sRGB
             let cgImage = try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: config)
-            return NSImage(cgImage: cgImage, size: rect.size)
+            return Self.nsImage(from: cgImage, logicalSize: rect.size)
         } catch {
             return fallbackCapture(rect: rect)
         }
@@ -182,7 +182,17 @@ final class CaptureEngine {
 
     private func fallbackCapture(rect: CGRect) -> NSImage? {
         guard let cgImage = CGWindowListCreateImage(rect, .optionAll, kCGNullWindowID, .bestResolution) else { return nil }
-        return NSImage(cgImage: cgImage, size: rect.size)
+        return Self.nsImage(from: cgImage, logicalSize: rect.size)
+    }
+
+    /// Creates an NSImage backed by NSBitmapImageRep so the raw CGImage pixels
+    /// are preserved through the entire pipeline (no CoreGraphics re-render).
+    static func nsImage(from cgImage: CGImage, logicalSize: NSSize) -> NSImage {
+        let rep = NSBitmapImageRep(cgImage: cgImage)
+        rep.size = logicalSize   // logical size for display; pixel data untouched
+        let image = NSImage(size: logicalSize)
+        image.addRepresentation(rep)
+        return image
     }
 
     // MARK: – OCR notification

--- a/Sources/Shotnix/History/HistoryManager.swift
+++ b/Sources/Shotnix/History/HistoryManager.swift
@@ -9,7 +9,9 @@ final class HistoryManager: ObservableObject {
     private let indexURL: URL
 
     init() {
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        guard let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            fatalError("[Shotnix] Application Support directory not found")
+        }
         storageDir = appSupport.appendingPathComponent("Shotnix/History", isDirectory: true)
         indexURL   = storageDir.appendingPathComponent("index.json")
         try? FileManager.default.createDirectory(at: storageDir, withIntermediateDirectories: true)
@@ -80,13 +82,12 @@ final class HistoryManager: ObservableObject {
     // MARK: – Image saving
 
     private func saveImage(_ image: NSImage, to path: String, size: CGSize?) {
-        if let size {
-            let thumb = image.resizedForThumbnail(to: size)
-            guard let png = ImageExporter.pngData(from: thumb) else { return }
-            try? png.write(to: URL(fileURLWithPath: path))
-        } else {
-            guard let png = ImageExporter.pngData(from: image) else { return }
-            try? png.write(to: URL(fileURLWithPath: path))
+        let source = size != nil ? image.resizedForThumbnail(to: size!) : image
+        guard let png = ImageExporter.pngData(from: source) else { return }
+        do {
+            try png.write(to: URL(fileURLWithPath: path))
+        } catch {
+            print("[Shotnix] Failed to write image to \(path): \(error)")
         }
     }
 

--- a/Sources/Shotnix/History/HistoryPanelController.swift
+++ b/Sources/Shotnix/History/HistoryPanelController.swift
@@ -184,7 +184,7 @@ private final class HistoryCell: NSView {
     }
 
     @objc private func saveImage() {
-        ImageExporter.saveWithPanel(image: item.fullImage, suggestedName: "screenshot")
+        ImageExporter.saveWithPanel(image: item.fullImage, suggestedName: ImageExporter.timestampedName)
     }
     @objc private func pinImage() { PinnedWindow.pin(image: item.fullImage) }
     @objc private func deleteItem() {

--- a/Sources/Shotnix/History/HistoryPanelController.swift
+++ b/Sources/Shotnix/History/HistoryPanelController.swift
@@ -18,6 +18,11 @@ final class HistoryPanelController: NSObject {
             reload()
             return
         }
+        // Register for close notification to restore activation policy
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(panelDidClose),
+            name: NSWindow.willCloseNotification, object: nil
+        )
         let p = NSPanel(
             contentRect: NSRect(x: 0, y: 0, width: 600, height: 480),
             styleMask: [.titled, .closable, .resizable, .utilityWindow],
@@ -95,6 +100,12 @@ final class HistoryPanelController: NSObject {
     private func reload() {
         guard let panel, let manager = historyManager else { return }
         panel.contentView = buildContent(historyManager: manager)
+    }
+
+    @objc private func panelDidClose(_ notification: Notification) {
+        guard let closedWindow = notification.object as? NSWindow, closedWindow === panel else { return }
+        panel = nil
+        NSApp.setActivationPolicy(.prohibited)
     }
 
     @objc private func clearAll() {

--- a/Sources/Shotnix/Overlay/QuickAccessOverlay.swift
+++ b/Sources/Shotnix/Overlay/QuickAccessOverlay.swift
@@ -266,7 +266,11 @@ private final class QuickAccessWindow: NSWindow {
         })
     }
 
+    private var didCleanup = false
+
     private func forceCleanup() {
+        guard !didCleanup else { return }
+        didCleanup = true
         removeEventMonitors()
         orderOut(nil)
         QuickAccessWindow.openWindows.removeAll { $0 === self }

--- a/Sources/Shotnix/Overlay/QuickAccessOverlay.swift
+++ b/Sources/Shotnix/Overlay/QuickAccessOverlay.swift
@@ -288,7 +288,7 @@ private final class QuickAccessWindow: NSWindow {
     }
 
     @objc private func saveAction() {
-        ImageExporter.saveWithPanel(image: image, suggestedName: "Shotnix-\(Date().formatted(.iso8601.year().month().day()))")
+        ImageExporter.saveWithPanel(image: image, suggestedName: ImageExporter.timestampedName)
         animatedClose()
     }
 
@@ -369,10 +369,7 @@ private final class ImageFilePromiseDelegate: NSObject, NSFilePromiseProviderDel
     }
 
     func filePromiseProvider(_ filePromiseProvider: NSFilePromiseProvider, fileNameForType fileType: String) -> String {
-        let ts = ISO8601DateFormatter()
-        ts.formatOptions = [.withFullDate, .withTime, .withColonSeparatorInTime]
-        let name = ts.string(from: Date()).replacingOccurrences(of: ":", with: "-")
-        return "Shotnix-\(name).png"
+        "\(ImageExporter.timestampedName).png"
     }
 
     func filePromiseProvider(_ filePromiseProvider: NSFilePromiseProvider, writePromiseTo url: URL, completionHandler handler: @escaping (Error?) -> Void) {

--- a/Sources/Shotnix/Utilities/ImageExporter.swift
+++ b/Sources/Shotnix/Utilities/ImageExporter.swift
@@ -27,6 +27,13 @@ enum ImageExporter {
         }
     }
 
+    /// Generates a filename like "Shotnix 2026-04-12 at 10.30.48" (matches CleanShot convention).
+    static var timestampedName: String {
+        let df = DateFormatter()
+        df.dateFormat = "yyyy-MM-dd 'at' HH.mm.ss"
+        return "Shotnix \(df.string(from: Date()))"
+    }
+
     // MARK: – Save with panel
 
     static func saveWithPanel(image: NSImage, suggestedName: String) {
@@ -59,7 +66,7 @@ enum ImageExporter {
         guard let cgImage = image.bestCGImage else { return nil }
         let data = NSMutableData()
         guard let dest = CGImageDestinationCreateWithData(data, "public.png" as CFString, 1, nil) else { return nil }
-        CGImageDestinationAddImage(dest, cgImage, nil)
+        CGImageDestinationAddImage(dest, cgImage, dpiProperties(for: image, cgImage: cgImage))
         guard CGImageDestinationFinalize(dest) else { return nil }
         return data as Data
     }
@@ -68,24 +75,56 @@ enum ImageExporter {
         guard let cgImage = image.bestCGImage else { return nil }
         let data = NSMutableData()
         guard let dest = CGImageDestinationCreateWithData(data, "public.jpeg" as CFString, 1, nil) else { return nil }
-        let opts: [CFString: Any] = [kCGImageDestinationLossyCompressionQuality: quality]
+        var opts = dpiDict(for: image, cgImage: cgImage)
+        opts[kCGImageDestinationLossyCompressionQuality] = quality
         CGImageDestinationAddImage(dest, cgImage, opts as CFDictionary)
         guard CGImageDestinationFinalize(dest) else { return nil }
         return data as Data
+    }
+
+    /// Compute DPI metadata from the pixel-to-point ratio of the image.
+    /// On Retina (2x), pixels = 2 × points → DPI = 144. On 1x → DPI = 72.
+    private static func dpiProperties(for image: NSImage, cgImage: CGImage) -> CFDictionary {
+        dpiDict(for: image, cgImage: cgImage) as CFDictionary
+    }
+
+    private static func dpiDict(for image: NSImage, cgImage: CGImage) -> [CFString: Any] {
+        guard image.size.width > 0 else { return [:] }
+        let scale = CGFloat(cgImage.width) / image.size.width
+        let dpi = 72.0 * scale
+        return [
+            kCGImagePropertyDPIWidth: dpi,
+            kCGImagePropertyDPIHeight: dpi,
+        ]
     }
 }
 
 extension NSImage {
     /// Extract the highest-resolution CGImage backing this NSImage.
+    /// Prefers the raw CGImage from NSBitmapImageRep (zero resampling) over
+    /// cgImage(forProposedRect:) which re-renders through CoreGraphics and
+    /// can introduce interpolation blur.
     var bestCGImage: CGImage? {
-        // Prefer the CGImage directly from representations (avoids resampling)
+        // 1. Direct extraction from NSBitmapImageRep (pixel-perfect, no resampling)
+        var best: CGImage?
+        var bestPixels = 0
         for rep in representations {
             if let bitmapRep = rep as? NSBitmapImageRep, let cg = bitmapRep.cgImage {
-                return cg
+                let pixels = cg.width * cg.height
+                if pixels > bestPixels {
+                    best = cg
+                    bestPixels = pixels
+                }
             }
         }
-        // Fallback: render into a CGImage at full pixel dimensions
-        var proposedRect = CGRect(origin: .zero, size: size)
-        return cgImage(forProposedRect: &proposedRect, context: nil, hints: [.ctm: AffineTransform.identity])
+        if let best { return best }
+
+        // 2. Fallback: render at FULL pixel dimensions (not logical size)
+        //    Use the largest representation's pixel size to avoid downscaling.
+        let maxRep = representations.max(by: { $0.pixelsWide * $0.pixelsHigh < $1.pixelsWide * $1.pixelsHigh })
+        let pixelW = maxRep?.pixelsWide ?? Int(size.width)
+        let pixelH = maxRep?.pixelsHigh ?? Int(size.height)
+        var proposedRect = CGRect(x: 0, y: 0, width: pixelW, height: pixelH)
+        return cgImage(forProposedRect: &proposedRect, context: nil, hints: nil)
     }
 }


### PR DESCRIPTION
## Summary
- **Pixel-perfect screenshot quality** — `NSImage(cgImage:size:)` created a private representation that `bestCGImage` couldn't extract, causing CoreGraphics re-render with interpolation blur. Fixed by wrapping in `NSBitmapImageRep` directly.
- **DPI metadata** — PNG/JPEG exports now embed correct DPI (144 on Retina, 72 on 1x) so Preview/Quick Look display at correct logical size.
- **Timestamped filenames** — All save paths now use `Shotnix 2026-04-12 at 10.30.48` format (same as CleanShot) instead of date-only names that caused conflicts.
- **Version bump** to 0.9.1-beta with full changelog in About window.

## Test plan
- [ ] Take screenshot with Shotnix, compare quality side-by-side with CleanShot X — text should be equally sharp
- [ ] Check DPI: `sips --getProperty dpiWidth` should show 144 on Retina captures
- [ ] Save screenshot — filename should include time (not just date)
- [ ] Drag-and-drop from overlay — dropped file should have timestamped name
- [ ] About window shows 0.9.1-beta with new changelog entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)