### PR TITLE
fix: use display's native ICC profile for CleanShot-level color accuracy

### DIFF
--- a/Sources/Shotnix/Capture/CaptureEngine.swift
+++ b/Sources/Shotnix/Capture/CaptureEngine.swift
@@ -159,9 +159,9 @@ final class CaptureEngine {
             config.scalesToFit = false
             config.showsCursor = false
             config.captureResolution = .best
-            // Preserve the display's native color space (Display P3 on modern Macs).
-            // sRGB forces a gamut conversion that can subtly degrade quality.
-            config.colorSpaceName = CGColorSpace.displayP3
+            // Don't set colorSpaceName — SCK defaults to the display's native
+            // calibrated ICC profile, preserving exact on-screen colors.
+            // Forcing sRGB or Display P3 overrides the display calibration.
 
             let cgImage = try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: config)
 

--- a/Sources/Shotnix/Utilities/ImageExporter.swift
+++ b/Sources/Shotnix/Utilities/ImageExporter.swift
@@ -66,7 +66,9 @@ enum ImageExporter {
         guard let cgImage = image.bestCGImage else { return nil }
         let data = NSMutableData()
         guard let dest = CGImageDestinationCreateWithData(data, "public.png" as CFString, 1, nil) else { return nil }
-        CGImageDestinationAddImage(dest, cgImage, dpiProperties(for: image, cgImage: cgImage))
+        // No custom DPI properties — CGImageDestination embeds the CGImage's
+        // native ICC profile and lets the OS handle DPI (same as CleanShot X).
+        CGImageDestinationAddImage(dest, cgImage, nil)
         guard CGImageDestinationFinalize(dest) else { return nil }
         return data as Data
     }
@@ -75,27 +77,10 @@ enum ImageExporter {
         guard let cgImage = image.bestCGImage else { return nil }
         let data = NSMutableData()
         guard let dest = CGImageDestinationCreateWithData(data, "public.jpeg" as CFString, 1, nil) else { return nil }
-        var opts = dpiDict(for: image, cgImage: cgImage)
-        opts[kCGImageDestinationLossyCompressionQuality] = quality
+        let opts: [CFString: Any] = [kCGImageDestinationLossyCompressionQuality: quality]
         CGImageDestinationAddImage(dest, cgImage, opts as CFDictionary)
         guard CGImageDestinationFinalize(dest) else { return nil }
         return data as Data
-    }
-
-    /// Compute DPI metadata from the pixel-to-point ratio of the image.
-    /// On Retina (2x), pixels = 2 × points → DPI = 144. On 1x → DPI = 72.
-    private static func dpiProperties(for image: NSImage, cgImage: CGImage) -> CFDictionary {
-        dpiDict(for: image, cgImage: cgImage) as CFDictionary
-    }
-
-    private static func dpiDict(for image: NSImage, cgImage: CGImage) -> [CFString: Any] {
-        guard image.size.width > 0 else { return [:] }
-        let scale = CGFloat(cgImage.width) / image.size.width
-        let dpi = 72.0 * scale
-        return [
-            kCGImagePropertyDPIWidth: dpi,
-            kCGImagePropertyDPIHeight: dpi,
-        ]
     }
 }
 


### PR DESCRIPTION
## Summary
- **Native ICC profile** — stop forcing Display P3; let SCK embed the display's actual calibrated profile (same as CleanShot X)
- **Remove manual DPI** — CGImageDestination handles DPI natively; our manual pHYs had rounding errors (2834 vs 2835)

Reverse-engineered CleanShot X's PNG structure: they use a 3364-byte display-specific ICC profile with vcgt gamma tables. We were overriding this with a generic 536-byte Display P3 profile.

## Test plan
- [ ] Take screenshot, verify ICC profile matches display calibration
- [ ] Compare colors side-by-side with CleanShot — should now match exactly
- [ ] PNG structure should no longer have incorrect pHYs values

🤖 Generated with [Claude Code](https://claude.com/claude-code)