### PR TITLE
fix: reduce overlay thumbnail to CleanShot X size

### DIFF
--- a/Sources/Shotnix/Overlay/QuickAccessOverlay.swift
+++ b/Sources/Shotnix/Overlay/QuickAccessOverlay.swift
@@ -30,9 +30,9 @@ private final class QuickAccessWindow: NSWindow {
         self.historyItem = historyItem
         self.historyManager = historyManager
 
-        let thumbW: CGFloat = 300
+        let thumbW: CGFloat = 220
         let aspect = image.size.height / max(image.size.width, 1)
-        let thumbH: CGFloat = min(thumbW * aspect, 200)
+        let thumbH: CGFloat = min(thumbW * aspect, 150)
         let buttonRowH: CGFloat = 32
         let separatorH: CGFloat = 0.5
         let progressH: CGFloat = 1.5


### PR DESCRIPTION
## Summary

- Reduce overlay thumbnail from 300px to 220px wide (max height 150px)
- Matches CleanShot X's compact floating card proportions
- 300px was too dominant in the screen corner

🤖 Generated with [Claude Code](https://claude.com/claude-code)