### PR TITLE
v0.9.3: annotation toolbar cleanup, canvas centering, overlay polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.9.3-beta] - 2026-04-14
+
+### Fixed
+- **Annotation editor blank area** — canvas now centers in viewport when window is wider than the image
+- **Annotation toolbar clutter** — removed always-visible Undo/Redo/Del buttons (keyboard shortcuts still work: ⌘Z, ⌘⇧Z, Delete); Crop✓ only appears when a crop region is drawn
+
+### Changed
+- **Quick access overlay** — refined shadow, corner radius (12px), frosted glass controls, white border for polish
+- **Menu bar icon** — switched to `viewfinder` symbol with medium weight for sharper clarity
+- **Annotation editor background** — dark gray backdrop instead of system gray for a professional editor feel
+- **Overlay context menu** — added Delete option
+
 ## [0.9.2-beta] - 2026-04-12
 
 ### Fixed

--- a/Info.plist
+++ b/Info.plist
@@ -11,7 +11,7 @@
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.2-beta</string>
+    <string>0.9.3-beta</string>
     <key>CFBundleExecutable</key>
     <string>Shotnix</string>
     <key>CFBundlePackageType</key>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ---
 
 > [!NOTE]
-> **Shotnix is in beta (v0.9.2).** It's fully functional but not yet notarized through Apple's Developer Program, so macOS will show a Gatekeeper warning on first launch. This is standard for open-source apps — Shotnix is safe and the source code is right here. Notarization is on the roadmap.
+> **Shotnix is in beta (v0.9.3).** It's fully functional but not yet notarized through Apple's Developer Program, so macOS will show a Gatekeeper warning on first launch. This is standard for open-source apps — Shotnix is safe and the source code is right here. Notarization is on the roadmap.
 >
 > To open: **Right-click → Open → Open** (macOS 13–14) or **System Settings → Privacy & Security → Open Anyway** (macOS 15+).
 
@@ -157,6 +157,7 @@ That's it. One dependency.
 - [x] WebP export
 - [x] After-capture auto-actions
 - [x] Premium overlay redesign (hover controls, spring animations, swipe-to-dismiss)
+- [x] Clean annotation toolbar (contextual buttons, centered canvas, dark editor background)
 - [ ] Customizable hotkeys
 - [ ] Window capture with shadow and padding
 - [ ] Delay/timer capture (3s, 5s, 10s)

--- a/Sources/Shotnix/Annotation/AnnotationCanvas.swift
+++ b/Sources/Shotnix/Annotation/AnnotationCanvas.swift
@@ -32,7 +32,6 @@ final class AnnotationCanvas: NSView {
 
     override init(frame: NSRect) {
         super.init(frame: frame)
-        wantsLayer = true
     }
 
     required init?(coder: NSCoder) { fatalError() }

--- a/Sources/Shotnix/Annotation/AnnotationWindowController.swift
+++ b/Sources/Shotnix/Annotation/AnnotationWindowController.swift
@@ -31,7 +31,14 @@ final class AnnotationWindowController: NSWindowController {
 
         let canvasSize = image.size
         let toolbarHeight: CGFloat = 52
-        let windowSize = NSSize(width: canvasSize.width, height: canvasSize.height + toolbarHeight)
+
+        // Cap window to 85% of screen so large screenshots don't go off-screen
+        let screenFrame = NSScreen.main?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1280, height: 800)
+        let maxW = screenFrame.width * 0.85
+        let maxH = screenFrame.height * 0.85 - toolbarHeight
+        let winW = min(canvasSize.width, maxW)
+        let winH = min(canvasSize.height, maxH) + toolbarHeight
+        let windowSize = NSSize(width: winW, height: winH)
 
         let win = NSWindow(
             contentRect: NSRect(origin: .zero, size: windowSize),
@@ -41,29 +48,66 @@ final class AnnotationWindowController: NSWindowController {
         )
         win.title = "Shotnix — Annotate"
         win.isReleasedWhenClosed = false
+        win.minSize = NSSize(width: 320, height: 240 + toolbarHeight)
         win.center()
 
         super.init(window: win)
 
         canvas.backgroundImage = image
-        canvas.frame = NSRect(x: 0, y: 0, width: canvasSize.width, height: canvasSize.height)
-        toolbar.frame = NSRect(x: 0, y: canvasSize.height, width: canvasSize.width, height: toolbarHeight)
+        canvas.frame = NSRect(origin: .zero, size: canvasSize)
 
-        toolbar.onToolChanged     = { [weak self] tool  in self?.canvas.activeTool = tool }
+        // Scroll view for canvas — clips content properly
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: winW, height: winH - toolbarHeight))
+        // Center canvas when viewport is larger than the image (eliminates blank side areas)
+        let clipView = CenteringClipView()
+        clipView.drawsBackground = false
+        scrollView.contentView = clipView
+        scrollView.documentView = canvas
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = true
+        scrollView.autohidesScrollers = true
+        scrollView.drawsBackground = true
+        scrollView.backgroundColor = NSColor(white: 0.12, alpha: 1.0)
+        scrollView.autoresizingMask = [.width, .height]
+        scrollView.horizontalScrollElasticity = .none
+        scrollView.verticalScrollElasticity = .none
+
+        // Toolbar positioned at top of window
+        toolbar.frame = NSRect(x: 0, y: winH - toolbarHeight, width: winW, height: toolbarHeight)
+        toolbar.autoresizingMask = [.width, .minYMargin]
+
+        toolbar.onToolChanged     = { [weak self] tool in
+            self?.canvas.activeTool = tool
+            // Clear crop state when switching away from crop tool
+            if tool != .crop {
+                self?.canvas.cropRect = nil
+                self?.canvas.setNeedsDisplay(self?.canvas.bounds ?? .zero)
+                self?.toolbar.setCropApplyVisible(false)
+            }
+        }
         toolbar.onColorChanged    = { [weak self] color in self?.canvas.activeColor = color }
         toolbar.onLineWidthChanged = { [weak self] w   in self?.canvas.activeLineWidth = w }
-        toolbar.onUndo            = { [weak self] in self?.canvas.performUndo() }
-        toolbar.onRedo            = { [weak self] in self?.canvas.performRedo() }
         toolbar.onSave            = { [weak self] in self?.save() }
         toolbar.onCopy            = { [weak self] in self?.copyToClipboard() }
-        toolbar.onDelete          = { [weak self] in self?.canvas.deleteSelected() }
         toolbar.onApplyCrop       = { [weak self] in self?.applyCrop() }
 
+        // Show Crop✓ button only when a crop region is drawn
+        canvas.onCropChanged = { [weak self] rect in
+            let hasCrop = rect != nil && !(rect?.isEmpty ?? true)
+            self?.toolbar.setCropApplyVisible(hasCrop)
+        }
+
+        // Build hierarchy FIRST, then configure layers (layers don't exist until views are in a window)
         let container = NSView(frame: NSRect(origin: .zero, size: windowSize))
-        container.addSubview(canvas)
+        container.addSubview(scrollView)
         container.addSubview(toolbar)
         win.contentView = container
         win.delegate = self
+
+        // NOW layers exist — set masksToBounds on the clip view (the actual clipping mechanism)
+        scrollView.contentView.wantsLayer = true
+        scrollView.contentView.layer?.masksToBounds = true
+
         win.makeFirstResponder(canvas)
     }
 
@@ -117,6 +161,25 @@ extension AnnotationWindowController: NSWindowDelegate {
     }
 }
 
+// MARK: – Centering Clip View
+
+/// Centers the document view when the scroll view viewport is larger than the content.
+@MainActor
+final class CenteringClipView: NSClipView {
+    override func constrainBoundsRect(_ proposedBounds: NSRect) -> NSRect {
+        var rect = super.constrainBoundsRect(proposedBounds)
+        guard let documentView = documentView else { return rect }
+        let docFrame = documentView.frame
+        if docFrame.width < rect.width {
+            rect.origin.x = (docFrame.width - rect.width) / 2
+        }
+        if docFrame.height < rect.height {
+            rect.origin.y = (docFrame.height - rect.height) / 2
+        }
+        return rect
+    }
+}
+
 // MARK: – Toolbar
 
 @MainActor
@@ -125,16 +188,14 @@ final class AnnotationToolbar: NSView {
     var onToolChanged: ((AnnotationTool) -> Void)?
     var onColorChanged: ((NSColor) -> Void)?
     var onLineWidthChanged: ((CGFloat) -> Void)?
-    var onUndo: (() -> Void)?
-    var onRedo: (() -> Void)?
     var onSave: (() -> Void)?
     var onCopy: (() -> Void)?
-    var onDelete: (() -> Void)?
     var onApplyCrop: (() -> Void)?
 
     private var toolButtons: [AnnotationTool: NSButton] = [:]
     private var selectedTool: AnnotationTool = .arrow
     private let colorWell = NSColorWell()
+    private var cropApplyButton: NSButton?
 
     override init(frame: NSRect) {
         super.init(frame: frame)
@@ -187,17 +248,23 @@ final class AnnotationToolbar: NSView {
         sep2.frame = NSRect(x: x, y: 6, width: 1, height: 40)
         addSubview(sep2); x += 12
 
-        // Action buttons
-        for (title, sel) in [("↩ Undo", #selector(undoTapped)), ("↪ Redo", #selector(redoTapped)),
-                              ("⌫ Del", #selector(deleteTapped)), ("Crop✓", #selector(cropTapped)),
-                              ("Copy", #selector(copyTapped)), ("Save", #selector(saveTapped))] {
+        // Always-visible action buttons
+        for (title, sel) in [("Copy", #selector(copyTapped)), ("Save", #selector(saveTapped))] {
             let btn = NSButton(title: title, target: self, action: sel)
             btn.bezelStyle = .rounded
             btn.font = .systemFont(ofSize: 11)
-            let w: CGFloat = title.count > 5 ? 60 : 50
-            btn.frame = NSRect(x: x, y: 11, width: w, height: 28)
-            addSubview(btn); x += w + 4
+            btn.frame = NSRect(x: x, y: 11, width: 50, height: 28)
+            addSubview(btn); x += 54
         }
+
+        // Crop apply button (only visible when a crop region is drawn)
+        let cropBtn = NSButton(title: "Crop✓", target: self, action: #selector(cropTapped))
+        cropBtn.bezelStyle = .rounded
+        cropBtn.font = .systemFont(ofSize: 11)
+        cropBtn.frame = NSRect(x: x, y: 11, width: 60, height: 28)
+        cropBtn.isHidden = true
+        addSubview(cropBtn)
+        cropApplyButton = cropBtn
 
         selectTool(.arrow)
     }
@@ -228,11 +295,12 @@ final class AnnotationToolbar: NSView {
         toolButtons[tool]?.layer?.cornerRadius = 6
     }
 
+    func setCropApplyVisible(_ visible: Bool) {
+        cropApplyButton?.isHidden = !visible
+    }
+
     @objc private func colorChanged()     { onColorChanged?(colorWell.color) }
     @objc private func lineWidthChanged(_ sender: NSSlider) { onLineWidthChanged?(CGFloat(sender.doubleValue)) }
-    @objc private func undoTapped()       { onUndo?() }
-    @objc private func redoTapped()       { onRedo?() }
-    @objc private func deleteTapped()     { onDelete?() }
     @objc private func cropTapped()       { onApplyCrop?() }
     @objc private func copyTapped()       { onCopy?() }
     @objc private func saveTapped()       { onSave?() }

--- a/Sources/Shotnix/App/AppDelegate.swift
+++ b/Sources/Shotnix/App/AppDelegate.swift
@@ -26,8 +26,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func setupStatusItem() {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
         guard let button = statusItem.button else { return }
-        button.image = NSImage(systemSymbolName: "camera.viewfinder", accessibilityDescription: "Shotnix")
-        button.image?.isTemplate = true
+        let config = NSImage.SymbolConfiguration(pointSize: 14, weight: .medium, scale: .medium)
+        let icon = NSImage(systemSymbolName: "viewfinder", accessibilityDescription: "Shotnix")?
+            .withSymbolConfiguration(config)
+        icon?.isTemplate = true
+        button.image = icon
         statusItem.menu = buildMenu()
     }
 

--- a/Sources/Shotnix/Overlay/QuickAccessOverlay.swift
+++ b/Sources/Shotnix/Overlay/QuickAccessOverlay.swift
@@ -50,7 +50,7 @@ private final class QuickAccessWindow: NSWindow {
         isOpaque = false
         backgroundColor = .clear
         level = .floating
-        hasShadow = false
+        hasShadow = true
         isMovableByWindowBackground = true
         acceptsMouseMovedEvents = true
         collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
@@ -152,6 +152,7 @@ private final class QuickAccessWindow: NSWindow {
         menu.addItem(NSMenuItem(title: "Edit", action: #selector(editAction), keyEquivalent: "e"))
         menu.addItem(NSMenuItem(title: "Pin", action: #selector(pinAction), keyEquivalent: ""))
         menu.addItem(.separator())
+        menu.addItem(NSMenuItem(title: "Delete", action: #selector(deleteAction), keyEquivalent: ""))
         menu.addItem(NSMenuItem(title: "Close", action: #selector(dismissAction), keyEquivalent: ""))
         for item in menu.items { item.target = self }
         guard let view = contentView else { return }
@@ -161,30 +162,32 @@ private final class QuickAccessWindow: NSWindow {
     private func buildContent(thumbW: CGFloat, thumbH: CGFloat, progressH: CGFloat, totalH: CGFloat) {
         let container = OverlayContentView(frame: NSRect(x: 0, y: 0, width: thumbW, height: totalH))
         container.wantsLayer = true
-        container.layer?.cornerRadius = 8
+        container.layer?.cornerRadius = 12
         container.layer?.cornerCurve = .continuous
         container.layer?.masksToBounds = false
         container.layer?.shadowColor = NSColor.black.cgColor
-        container.layer?.shadowOpacity = 0.35
-        container.layer?.shadowRadius = 24
-        container.layer?.shadowOffset = CGSize(width: 0, height: -6)
+        container.layer?.shadowOpacity = 0.55
+        container.layer?.shadowRadius = 30
+        container.layer?.shadowOffset = CGSize(width: 0, height: -10)
         contentView = container
 
         // Clip subviews so content respects corner radius while shadow remains visible
         let clipView = NSView(frame: container.bounds)
         clipView.wantsLayer = true
-        clipView.layer?.cornerRadius = 8
+        clipView.layer?.cornerRadius = 12
         clipView.layer?.cornerCurve = .continuous
         clipView.layer?.masksToBounds = true
+        // Subtle dark tint — frames content, visible at rounded corners and behind image
+        clipView.layer?.backgroundColor = NSColor.black.withAlphaComponent(0.08).cgColor
         container.addSubview(clipView)
 
-        // Subtle inner border — gives definition against any background color
+        // White border — primary edge definition on light wallpapers (shadow handles dark)
         let borderView = NSView(frame: container.bounds)
         borderView.wantsLayer = true
-        borderView.layer?.cornerRadius = 8
+        borderView.layer?.cornerRadius = 12
         borderView.layer?.cornerCurve = .continuous
-        borderView.layer?.borderWidth = 0.5
-        borderView.layer?.borderColor = NSColor.white.withAlphaComponent(0.12).cgColor
+        borderView.layer?.borderWidth = 1.5
+        borderView.layer?.borderColor = NSColor.white.withAlphaComponent(0.35).cgColor
         container.addSubview(borderView)
 
         // Draggable thumbnail — drag to Finder/apps, double-click to annotate
@@ -203,48 +206,87 @@ private final class QuickAccessWindow: NSWindow {
         thumb.onDragCompleted = { [weak self] in self?.animatedClose() }
         clipView.addSubview(thumb)
 
-        // Controls overlay — dark gradient scrim with action buttons, hidden by default
-        let controlsH: CGFloat = 40
-        let controls = NSView(frame: NSRect(x: 0, y: progressH, width: thumbW, height: controlsH))
+        // Controls overlay — frosted glass + corner circles + center pills
+        let controls = NSView(frame: NSRect(x: 0, y: progressH, width: thumbW, height: thumbH))
         controls.wantsLayer = true
 
-        let gradient = CAGradientLayer()
-        gradient.frame = controls.bounds
-        gradient.colors = [
-            NSColor.clear.cgColor,
-            NSColor.black.withAlphaComponent(0.55).cgColor
-        ]
-        gradient.startPoint = CGPoint(x: 0.5, y: 1)
-        gradient.endPoint = CGPoint(x: 0.5, y: 0)
-        controls.layer?.addSublayer(gradient)
+        // Frosted glass backdrop
+        let frost = NSVisualEffectView(frame: controls.bounds)
+        frost.material = .hudWindow
+        frost.blendingMode = .behindWindow
+        frost.state = .active
+        controls.addSubview(frost)
 
-        let actions: [(String, String, Selector)] = [
-            ("doc.on.clipboard",      "Copy",    #selector(copyAction)),
-            ("square.and.arrow.down", "Save",    #selector(saveAction)),
-            ("pencil",                "Edit",    #selector(editAction)),
-            ("pin",                   "Pin",     #selector(pinAction)),
-            ("xmark",                 "Close",   #selector(dismissAction)),
+        // ── Corner circles (28px glass buttons, all 4 corners) ──
+        let cSize: CGFloat = 28
+        let cMargin: CGFloat = 8
+        let cConfig = NSImage.SymbolConfiguration(pointSize: 12, weight: .medium)
+
+        let corners: [(String, String, Selector, CGFloat, CGFloat)] = [
+            ("pencil",  "Edit",   #selector(editAction),    cMargin,                   thumbH - cSize - cMargin),
+            ("xmark",   "Close",  #selector(dismissAction), thumbW - cSize - cMargin,  thumbH - cSize - cMargin),
+            ("trash",   "Delete", #selector(deleteAction),  cMargin,                   cMargin),
+            ("pin",     "Pin",    #selector(pinAction),     thumbW - cSize - cMargin,  cMargin),
         ]
-        let btnSize: CGFloat = 28
-        let spacing: CGFloat = 4
-        let totalBtnsW = CGFloat(actions.count) * btnSize + CGFloat(actions.count - 1) * spacing
-        let startX = (thumbW - totalBtnsW) / 2
-        let btnY: CGFloat = 6
-        let iconConfig = NSImage.SymbolConfiguration(pointSize: 12, weight: .semibold)
-        for (i, (icon, tooltip, sel)) in actions.enumerated() {
-            let btn = OverlayHoverButton(frame: NSRect(
-                x: startX + CGFloat(i) * (btnSize + spacing),
-                y: btnY, width: btnSize, height: btnSize
-            ))
-            btn.image = NSImage(systemSymbolName: icon, accessibilityDescription: tooltip)?.withSymbolConfiguration(iconConfig)
+        let screenScale = NSScreen.main?.backingScaleFactor ?? 2.0
+        for (icon, tip, sel, cx, cy) in corners {
+            let btn = OverlayCornerButton(frame: NSRect(x: cx, y: cy, width: cSize, height: cSize))
+            btn.image = NSImage(systemSymbolName: icon, accessibilityDescription: tip)?.withSymbolConfiguration(cConfig)
             btn.bezelStyle = .regularSquare
             btn.isBordered = false
-            btn.toolTip = tooltip
+            btn.toolTip = tip
             btn.target = self
             btn.action = sel
             btn.imageScaling = .scaleNone
             btn.contentTintColor = .white
+            btn.wantsLayer = true
+            btn.layer?.contentsScale = screenScale
+            btn.layer?.cornerRadius = cSize / 2
+            btn.layer?.cornerCurve = .continuous
+            btn.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.18).cgColor
             controls.addSubview(btn)
+        }
+
+        // ── Center pills (tight-fit white capsules) ──
+        let pillH: CGFloat = 28
+        let pillGap: CGFloat = 8
+        let pillPadding: CGFloat = 28  // total horizontal padding (14 each side)
+        let pillFont = NSFont.systemFont(ofSize: 13, weight: .medium)
+        let pillAttrs: [NSAttributedString.Key: Any] = [
+            .foregroundColor: NSColor.black.withAlphaComponent(0.85),
+            .font: pillFont,
+        ]
+
+        let pills: [(String, Selector)] = [
+            ("Copy", #selector(copyAction)),
+            ("Save", #selector(saveAction)),
+        ]
+
+        // Measure each pill to fit text snugly
+        let pillWidths = pills.map { title, _ in
+            ceil((title as NSString).size(withAttributes: pillAttrs).width) + pillPadding
+        }
+        let totalPillW = pillWidths.reduce(0, +) + CGFloat(pills.count - 1) * pillGap
+        let pillY = (thumbH - pillH) / 2
+        var pillCursorX = (thumbW - totalPillW) / 2
+
+        let retinaScale = NSScreen.main?.backingScaleFactor ?? 2.0
+        for (i, (title, sel)) in pills.enumerated() {
+            let pw = pillWidths[i]
+            let btn = OverlayPillButton(frame: NSRect(x: pillCursorX, y: pillY, width: pw, height: pillH))
+            btn.attributedTitle = NSAttributedString(string: title, attributes: pillAttrs)
+            btn.alignment = .center
+            btn.bezelStyle = .regularSquare
+            btn.isBordered = false
+            btn.target = self
+            btn.action = sel
+            btn.wantsLayer = true
+            btn.layer?.contentsScale = retinaScale
+            btn.layer?.cornerRadius = pillH / 2
+            btn.layer?.cornerCurve = .continuous
+            btn.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.92).cgColor
+            controls.addSubview(btn)
+            pillCursorX += pw + pillGap
         }
 
         controls.alphaValue = 0
@@ -296,19 +338,6 @@ private final class QuickAccessWindow: NSWindow {
             ctx.duration = 0.2
             controlsOverlay?.animator().alphaValue = hovered ? 1 : 0
         }
-
-        // Subtle scale-up on hover (1.0 → 1.02) for lively micro-interaction
-        guard let layer = contentView?.layer else { return }
-        let scale: CGFloat = hovered ? 1.02 : 1.0
-        let anim = CABasicAnimation(keyPath: "transform.scale")
-        anim.fromValue = hovered ? 1.0 : 1.02
-        anim.toValue = scale
-        anim.duration = 0.25
-        anim.timingFunction = CAMediaTimingFunction(controlPoints: 0.34, 1.56, 0.64, 1.0)
-        anim.fillMode = .forwards
-        anim.isRemovedOnCompletion = false
-        layer.add(anim, forKey: "hoverScale")
-        layer.transform = CATransform3DMakeScale(scale, scale, 1)
     }
 
     private func positionOverlay() {
@@ -397,6 +426,7 @@ private final class QuickAccessWindow: NSWindow {
     }
 
     private var isClosing = false
+    private var skipPolicyReset = false
 
     private func animatedClose() {
         guard !isClosing else { return }
@@ -425,7 +455,8 @@ private final class QuickAccessWindow: NSWindow {
         orderOut(nil)
         QuickAccessWindow.openWindows.removeAll { $0 === self }
         // Restore background-only policy so app doesn't appear in Cmd-Tab
-        if QuickAccessWindow.openWindows.isEmpty {
+        // (skip when transitioning to another window like editor or pin)
+        if QuickAccessWindow.openWindows.isEmpty && !skipPolicyReset {
             NSApp.setActivationPolicy(.prohibited)
         }
     }
@@ -472,13 +503,25 @@ private final class QuickAccessWindow: NSWindow {
     }
 
     @objc private func editAction() {
+        skipPolicyReset = true
         animatedClose()
-        AnnotationWindowController.open(image: image, historyItem: historyItem, historyManager: historyManager)
+        // Open after a short delay so cleanup doesn't kill activation
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [image, historyItem, historyManager] in
+            AnnotationWindowController.open(image: image, historyItem: historyItem, historyManager: historyManager)
+        }
     }
 
     @objc private func pinAction() {
+        skipPolicyReset = true
         animatedClose()
-        PinnedWindow.pin(image: image)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [image] in
+            PinnedWindow.pin(image: image)
+        }
+    }
+
+    @objc private func deleteAction() {
+        historyManager.delete(historyItem)
+        animatedClose()
     }
 
     @objc private func dismissAction() {
@@ -575,10 +618,10 @@ private final class OverlayContentView: NSView {
     override var acceptsFirstResponder: Bool { true }
 }
 
-// MARK: – Overlay hover button (white icon on dark scrim)
+// MARK: – Corner button (glass circle, secondary action)
 
 @MainActor
-private final class OverlayHoverButton: NSButton {
+private final class OverlayCornerButton: NSButton {
 
     private var trackingArea: NSTrackingArea?
 
@@ -591,12 +634,44 @@ private final class OverlayHoverButton: NSButton {
     }
 
     override func mouseEntered(with event: NSEvent) {
-        wantsLayer = true
-        layer?.backgroundColor = NSColor.white.withAlphaComponent(0.15).cgColor
-        layer?.cornerRadius = 6
+        layer?.backgroundColor = NSColor.white.withAlphaComponent(0.35).cgColor
     }
 
     override func mouseExited(with event: NSEvent) {
-        layer?.backgroundColor = nil
+        layer?.backgroundColor = NSColor.white.withAlphaComponent(0.18).cgColor
+    }
+}
+
+// MARK: – Pill button (white capsule, primary action)
+
+@MainActor
+private final class OverlayPillButton: NSButton {
+
+    private var trackingArea: NSTrackingArea?
+
+    // Kill all default NSButton drawing — layer handles everything
+    override func draw(_ dirtyRect: NSRect) {
+        // Draw only the attributed title, centered
+        guard let title = attributedTitle as NSAttributedString? else { return }
+        let size = title.size()
+        let x = (bounds.width - size.width) / 2
+        let y = (bounds.height - size.height) / 2
+        title.draw(at: NSPoint(x: x, y: y))
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let old = trackingArea { removeTrackingArea(old) }
+        let area = NSTrackingArea(rect: bounds, options: [.activeAlways, .mouseEnteredAndExited], owner: self)
+        addTrackingArea(area)
+        trackingArea = area
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        layer?.backgroundColor = NSColor.white.cgColor
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        layer?.backgroundColor = NSColor.white.withAlphaComponent(0.92).cgColor
     }
 }


### PR DESCRIPTION
## Summary
- **Annotation editor**: removed always-visible Undo/Redo/Del buttons (keyboard shortcuts still work), Crop✓ only appears when crop region is drawn, canvas centers when viewport > image, dark editor background
- **Quick access overlay**: refined shadow/border/corner radius, frosted glass controls, Delete option in context menu
- **Menu bar icon**: switched to viewfinder symbol with medium weight
- **Version bump**: 0.9.2-beta → 0.9.3-beta with updated CHANGELOG and README

## Test plan
- [ ] Open annotation editor — verify toolbar only shows tool icons, color, size, Copy, Save
- [ ] Select crop tool and drag region — verify Crop✓ appears; switch tool — verify it disappears
- [ ] Resize annotation window wider than image — verify canvas centers with dark background (no blank area)
- [ ] Capture screenshot — verify overlay styling (shadow, rounded corners, frosted controls)
- [ ] Right-click overlay — verify Delete option exists
- [ ] Check menu bar icon renders clearly

🤖 Generated with [Claude Code](https://claude.com/claude-code)