### PR TITLE
feat: add numbered step counter annotation tool

### DIFF
--- a/Sources/Shotnix/Annotation/AnnotationCanvas.swift
+++ b/Sources/Shotnix/Annotation/AnnotationCanvas.swift
@@ -173,6 +173,14 @@ final class AnnotationCanvas: NSView {
             beginTextEntry(at: point)
             return
         }
+        if activeTool == .numberedStep {
+            pushUndo()
+            let step = NumberedStepAnnotation(center: point, number: nextStepNumber())
+            step.color = activeColor
+            objects.append(step)
+            setNeedsDisplay(bounds)
+            return
+        }
 
         pushUndo()
         dragStart = point
@@ -307,6 +315,11 @@ final class AnnotationCanvas: NSView {
 
     private func rectFrom(_ a: CGPoint, to b: CGPoint) -> CGRect {
         CGRect(x: min(a.x,b.x), y: min(a.y,b.y), width: abs(b.x-a.x), height: abs(b.y-a.y))
+    }
+
+    private func nextStepNumber() -> Int {
+        let existing = objects.compactMap { ($0 as? NumberedStepAnnotation)?.number }
+        return (existing.max() ?? 0) + 1
     }
 
     // MARK: – Text

--- a/Sources/Shotnix/Annotation/AnnotationObject.swift
+++ b/Sources/Shotnix/Annotation/AnnotationObject.swift
@@ -4,7 +4,7 @@ import AppKit
 
 enum AnnotationTool: String, CaseIterable {
     case select, arrow, rectangle, filledRectangle, ellipse, line, freehand
-    case text, highlighter, blur, pixelate, crop
+    case text, numberedStep, highlighter, blur, pixelate, crop
 
     var icon: String {
         switch self {
@@ -16,6 +16,7 @@ enum AnnotationTool: String, CaseIterable {
         case .line:            return "line.diagonal"
         case .freehand:        return "pencil"
         case .text:            return "textformat"
+        case .numberedStep:    return "1.circle.fill"
         case .highlighter:     return "highlighter"
         case .blur:            return "camera.filters"
         case .pixelate:        return "square.grid.3x3.fill"
@@ -33,6 +34,7 @@ enum AnnotationTool: String, CaseIterable {
         case .line:            return "Line"
         case .freehand:        return "Freehand Draw"
         case .text:            return "Text"
+        case .numberedStep:    return "Numbered Steps"
         case .highlighter:     return "Highlighter"
         case .blur:            return "Blur"
         case .pixelate:        return "Pixelate"
@@ -392,4 +394,84 @@ final class TextAnnotation: AnnotationObject {
 
     func contains(point: CGPoint) -> Bool { bounds.insetBy(dx: -8, dy: -8).contains(point) }
     func move(by delta: CGPoint) { origin.x += delta.x; origin.y += delta.y }
+}
+
+// MARK: – Numbered Step
+
+final class NumberedStepAnnotation: AnnotationObject {
+    let id = UUID()
+    var color: NSColor = .systemRed
+    var lineWidth: CGFloat = 0
+    var isSelected = false
+    var origin: CGPoint
+    var number: Int
+    var diameter: CGFloat = 30
+
+    private lazy var cachedTextLayout: (font: NSFont, attrs: [NSAttributedString.Key: Any], size: CGSize) = {
+        let font = NSFont.boldSystemFont(ofSize: diameter * 0.55)
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: NSColor.white
+        ]
+        let size = ("\(number)" as NSString).size(withAttributes: attrs)
+        return (font, attrs, size)
+    }()
+
+    init(center: CGPoint, number: Int) {
+        self.origin = center
+        self.number = number
+    }
+
+    var bounds: CGRect {
+        CGRect(x: origin.x - diameter/2, y: origin.y - diameter/2,
+               width: diameter, height: diameter)
+    }
+
+    func contains(point: CGPoint) -> Bool {
+        let dx = point.x - origin.x
+        let dy = point.y - origin.y
+        return (dx*dx + dy*dy) <= (diameter/2 + 4) * (diameter/2 + 4)
+    }
+
+    func move(by delta: CGPoint) {
+        origin.x += delta.x
+        origin.y += delta.y
+    }
+
+    func draw(in ctx: CGContext, scale: CGFloat) {
+        ctx.saveGState()
+
+        let circleRect = bounds
+
+        // Shadow behind the circle
+        ctx.setShadow(offset: CGSize(width: 0, height: 1), blur: 3,
+                       color: NSColor.black.withAlphaComponent(0.3).cgColor)
+
+        // Filled circle
+        ctx.setFillColor(color.cgColor)
+        ctx.fillEllipse(in: circleRect)
+
+        // Reset shadow before drawing border and text
+        ctx.setShadow(offset: .zero, blur: 0)
+
+        // White border
+        ctx.setStrokeColor(NSColor.white.cgColor)
+        ctx.setLineWidth(1)
+        ctx.strokeEllipse(in: circleRect)
+
+        // Number text (centered, white, bold) — font + size cached as lazy property
+        let layout = cachedTextLayout
+        let textOrigin = CGPoint(
+            x: circleRect.midX - layout.size.width / 2,
+            y: circleRect.midY - layout.size.height / 2
+        )
+
+        NSGraphicsContext.saveGraphicsState()
+        let nsCtx = NSGraphicsContext(cgContext: ctx, flipped: true)
+        NSGraphicsContext.current = nsCtx
+        ("\(number)" as NSString).draw(at: textOrigin, withAttributes: layout.attrs)
+        NSGraphicsContext.restoreGraphicsState()
+
+        ctx.restoreGState()
+    }
 }

--- a/Sources/Shotnix/Annotation/AnnotationWindowController.swift
+++ b/Sources/Shotnix/Annotation/AnnotationWindowController.swift
@@ -211,7 +211,7 @@ final class AnnotationToolbar: NSView {
         var x: CGFloat = 8
 
         // Tool buttons
-        let tools: [AnnotationTool] = [.select, .arrow, .rectangle, .filledRectangle, .ellipse, .line, .freehand, .text, .highlighter, .blur, .pixelate, .crop]
+        let tools: [AnnotationTool] = [.select, .arrow, .rectangle, .filledRectangle, .ellipse, .line, .freehand, .text, .numberedStep, .highlighter, .blur, .pixelate, .crop]
         for tool in tools {
             let btn = makeToolButton(tool: tool)
             btn.frame = NSRect(x: x, y: 8, width: 34, height: 34)


### PR DESCRIPTION
## Summary
- Adds a new **Numbered Step Counter** annotation tool for tutorial/walkthrough screenshots
- Click-to-place incrementing numbered circles (1, 2, 3...) with auto-incrementing logic
- 30pt filled circles with white border, drop shadow, and centered bold white number
- Number derived by scanning existing steps (`max + 1`) — survives undo/redo/delete without bookkeeping

## Changes
| File | Change |
|---|---|
| `AnnotationObject.swift` | `numberedStep` enum case + `NumberedStepAnnotation` class with cached text layout |
| `AnnotationCanvas.swift` | Click-to-place handler in `mouseDown` + `nextStepNumber()` helper |
| `AnnotationWindowController.swift` | Toolbar button (`1.circle.fill` SF Symbol) |

## Design Decisions
- **Click-to-place** (no drag) — same interaction as text tool
- **No mutable counter** — number derived from scanning objects array at placement time
- **No renumbering on delete** — standard convention (1, 3, 4 after deleting step 2)
- **Cached text layout** — font, attrs, and text size computed once per instance (lazy property)

## Test plan
- [x] Build passes with zero new warnings
- [x] Security review (sentinel): 0 findings
- [x] Performance review (iridium): 3 LOW → fixed with cached text layout
- [x] .app bundle deployed and tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)