### PR TITLE
Polish capture performance and release v0.9.6-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.9.6-beta] - 2026-04-29
+
+### Added
+- **Fullscreen shortcut alias** — `Cmd + Shift + 3` now triggers Shotnix fullscreen capture when native macOS screenshot shortcuts are disabled, while `Cmd + Shift + 6` remains available.
+
+### Fixed
+- **Annotation undo correctness** — moving existing annotations now creates a proper undo checkpoint backed by deep-copied annotation snapshots.
+- **Scrolling capture retry after cancel** — canceling scrolling-area selection no longer leaves the controller stuck active.
+- **Desktop icon hiding preference** — “Hide desktop icons while capturing” now wraps capture flows and restores Finder state afterward.
+- **WebP fallback safety** — unsupported WebP exports now fall back to a real `.png` file instead of writing PNG bytes to a `.webp` filename.
+
+### Changed
+- **Performance polish** — reduced annotation redraw work, throttled window-selection hit testing, avoided overlapping scrolling-capture frames, and moved drag file promises off the main queue.
+- **Release packaging** — build signing now uses a committed entitlements file with hardened runtime options and no longer strips quarantine from the installed app.
+
 ## [0.9.5-beta] - 2026-04-25
 
 ### Added

--- a/Info.plist
+++ b/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleDisplayName</key>
     <string>Shotnix</string>
     <key>CFBundleVersion</key>
-    <string>6</string>
+    <string>7</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.5-beta</string>
+    <string>0.9.6-beta</string>
     <key>CFBundleExecutable</key>
     <string>Shotnix</string>
     <key>CFBundlePackageType</key>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ---
 
 > [!NOTE]
-> **Shotnix is in beta (v0.9.5).** It's fully functional but not yet notarized through Apple's Developer Program, so macOS will show a Gatekeeper warning on first launch. This is standard for open-source apps — Shotnix is safe and the source code is right here. Notarization is on the roadmap.
+> **Shotnix is in beta (v0.9.6).** It's fully functional but not yet notarized through Apple's Developer Program, so macOS will show a Gatekeeper warning on first launch. This is standard for open-source apps — Shotnix is safe and the source code is right here. Notarization is on the roadmap.
 >
 > To open: **Right-click → Open → Open** (macOS 13–14) or **System Settings → Privacy & Security → Open Anyway** (macOS 15+).
 
@@ -89,10 +89,7 @@ macOS has built-in screenshot tools, but they stop at capture. Shotnix picks up 
 > 2. Go to **System Settings → Privacy & Security**
 > 3. Scroll down and click **Open Anyway** next to "Shotnix was blocked"
 >
-> **Or use Terminal:**
-> ```
-> xattr -dr com.apple.quarantine /Applications/Shotnix.app
-> ```
+> If macOS still blocks the app, use **System Settings → Privacy & Security → Open Anyway**.
 
 ### Build from source
 
@@ -102,7 +99,7 @@ cd Shotnix
 bash build-app.sh
 ```
 
-This compiles a release build, generates the app icon, ad-hoc signs the binary, and copies `Shotnix.app` to your Desktop.
+This compiles a release build, assembles the app bundle, ad-hoc signs the binary, and copies `Shotnix.app` to `/Applications`.
 
 **Requirements:** macOS 13+, Swift 5.9+
 
@@ -112,7 +109,7 @@ This compiles a release build, generates the app icon, ad-hoc signs the binary, 
 |---|---|
 | `Cmd + Shift + 4` | Area capture |
 | `Cmd + Shift + 5` | Window capture |
-| `Cmd + Shift + 6` | Fullscreen capture |
+| `Cmd + Shift + 3` / `Cmd + Shift + 6` | Fullscreen capture |
 | `Cmd + Shift + 7` | Previous area capture |
 | `Cmd + Shift + O` | OCR text extraction |
 | `Cmd + Shift + S` | Scrolling capture |

--- a/Shotnix.entitlements
+++ b/Shotnix.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <false/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <false/>
+</dict>
+</plist>

--- a/Sources/Shotnix/Annotation/AnnotationCanvas.swift
+++ b/Sources/Shotnix/Annotation/AnnotationCanvas.swift
@@ -260,18 +260,20 @@ final class AnnotationCanvas: NSView {
             return
         }
         if activeTool == .crop, let start = dragStart {
+            let previous = cropRect
             cropRect = CGRect(
                 x: min(start.x, point.x), y: min(start.y, point.y),
                 width: abs(point.x - start.x), height: abs(point.y - start.y)
             )
             onCropChanged?(cropRect)
-            setNeedsDisplay(bounds)
+            invalidate(previous, cropRect, padding: 2)
             return
         }
 
+        let previousBounds = currentObject?.bounds
         updateCurrentObject(to: point)
         lastDragPoint = point
-        setNeedsDisplay(bounds)
+        invalidate(previousBounds, currentObject?.bounds, padding: activeLineWidth + 12)
     }
 
     override func mouseUp(with event: NSEvent) {
@@ -298,6 +300,7 @@ final class AnnotationCanvas: NSView {
 
     private var selectDragStart: CGPoint?
     private var selectObjectStart: [(UUID, CGPoint)] = []
+    private var didPushSelectMoveUndo = false
 
     private func handleSelectDown(point: CGPoint) {
         let hit = objects.last(where: { $0.contains(point: point) })
@@ -306,6 +309,7 @@ final class AnnotationCanvas: NSView {
                 selectedObjects = [hit]
             }
             selectDragStart = point
+            didPushSelectMoveUndo = false
             selectObjectStart = selectedObjects.map { ($0.id, CGPoint(x: $0.bounds.origin.x, y: $0.bounds.origin.y)) }
         } else {
             selectedObjects = []
@@ -316,15 +320,25 @@ final class AnnotationCanvas: NSView {
     private func handleSelectDrag(point: CGPoint) {
         guard let start = selectDragStart else { return }
         let delta = CGPoint(x: point.x - start.x, y: point.y - start.y)
+        guard delta.x != 0 || delta.y != 0 else { return }
+        if !didPushSelectMoveUndo {
+            pushUndo()
+            didPushSelectMoveUndo = true
+        }
+        let previousRects = selectedObjects.map(\.bounds)
         for obj in selectedObjects {
             obj.move(by: delta)
         }
         selectDragStart = point
-        setNeedsDisplay(bounds)
+        let currentRects = selectedObjects.map(\.bounds)
+        for rect in previousRects + currentRects {
+            setNeedsDisplay(rect.insetBy(dx: -12, dy: -12).intersection(bounds))
+        }
     }
 
     private func handleSelectUp(point: CGPoint) {
         selectDragStart = nil
+        didPushSelectMoveUndo = false
     }
 
     // MARK: – Object factory
@@ -369,7 +383,9 @@ final class AnnotationCanvas: NSView {
         case let r as RectangleAnnotation:   r.rect = rectFrom(start, to: point)
         case let e as EllipseAnnotation:     e.rect = rectFrom(start, to: point)
         case let l as LineAnnotation:        l.endPoint = point
-        case let f as FreehandAnnotation:    f.points.append(point)
+        case let f as FreehandAnnotation:
+            if let last = f.points.last, hypot(point.x - last.x, point.y - last.y) < 1.5 { return }
+            f.points.append(point)
         case let h as HighlighterAnnotation: h.endPoint = point
         case let b as BlurAnnotation:        b.rect = rectFrom(start, to: point)
         case let p as PixelateAnnotation:    p.rect = rectFrom(start, to: point)
@@ -379,6 +395,15 @@ final class AnnotationCanvas: NSView {
 
     private func rectFrom(_ a: CGPoint, to b: CGPoint) -> CGRect {
         CGRect(x: min(a.x,b.x), y: min(a.y,b.y), width: abs(b.x-a.x), height: abs(b.y-a.y))
+    }
+
+    private func invalidate(_ oldRect: CGRect?, _ newRect: CGRect?, padding: CGFloat) {
+        if let oldRect {
+            setNeedsDisplay(oldRect.insetBy(dx: -padding, dy: -padding).intersection(bounds))
+        }
+        if let newRect {
+            setNeedsDisplay(newRect.insetBy(dx: -padding, dy: -padding).intersection(bounds))
+        }
     }
 
     private func nextStepNumber() -> Int {
@@ -429,15 +454,13 @@ final class AnnotationCanvas: NSView {
     private var redoSnapshots: [(objects: [any AnnotationObject], selected: [any AnnotationObject])] = []
 
     func pushUndo() {
-        // Snapshot: copy the array (shallow — but since we only add/remove,
-        // the previously committed objects are never mutated)
-        undoSnapshots.append((objects: Array(objects), selected: Array(selectedObjects)))
+        undoSnapshots.append((objects: objects.map { $0.copy() }, selected: selectedObjects.map { $0.copy() }))
         redoSnapshots.removeAll()
     }
 
     func performUndo() {
         guard let prev = undoSnapshots.popLast() else { return }
-        redoSnapshots.append((objects: Array(objects), selected: Array(selectedObjects)))
+        redoSnapshots.append((objects: objects.map { $0.copy() }, selected: selectedObjects.map { $0.copy() }))
         objects = prev.objects
         selectedObjects = []
         setNeedsDisplay(bounds)
@@ -445,7 +468,7 @@ final class AnnotationCanvas: NSView {
 
     func performRedo() {
         guard let next = redoSnapshots.popLast() else { return }
-        undoSnapshots.append((objects: Array(objects), selected: Array(selectedObjects)))
+        undoSnapshots.append((objects: objects.map { $0.copy() }, selected: selectedObjects.map { $0.copy() }))
         objects = next.objects
         selectedObjects = []
         setNeedsDisplay(bounds)

--- a/Sources/Shotnix/Annotation/AnnotationObject.swift
+++ b/Sources/Shotnix/Annotation/AnnotationObject.swift
@@ -53,6 +53,7 @@ protocol AnnotationObject: AnyObject {
     func draw(in context: CGContext, scale: CGFloat)
     func contains(point: CGPoint) -> Bool
     func move(by delta: CGPoint)
+    func copy() -> any AnnotationObject
     var bounds: CGRect { get }
 }
 
@@ -122,6 +123,14 @@ final class ArrowAnnotation: AnnotationObject {
         endPoint.x += delta.x;   endPoint.y += delta.y
     }
 
+    func copy() -> any AnnotationObject {
+        let annotation = ArrowAnnotation(start: startPoint, end: endPoint)
+        annotation.color = color
+        annotation.lineWidth = lineWidth
+        annotation.isSelected = isSelected
+        return annotation
+    }
+
     private func distanceFromLineSegment(point p: CGPoint, a: CGPoint, b: CGPoint) -> CGFloat {
         let dx = b.x - a.x, dy = b.y - a.y
         let len2 = dx*dx + dy*dy
@@ -162,6 +171,13 @@ final class RectangleAnnotation: AnnotationObject {
 
     func contains(point: CGPoint) -> Bool { rect.insetBy(dx: -8, dy: -8).contains(point) }
     func move(by delta: CGPoint) { rect.origin.x += delta.x; rect.origin.y += delta.y }
+    func copy() -> any AnnotationObject {
+        let annotation = RectangleAnnotation(rect: rect, filled: filled)
+        annotation.color = color
+        annotation.lineWidth = lineWidth
+        annotation.isSelected = isSelected
+        return annotation
+    }
 }
 
 // MARK: – Ellipse
@@ -187,6 +203,13 @@ final class EllipseAnnotation: AnnotationObject {
 
     func contains(point: CGPoint) -> Bool { rect.insetBy(dx: -8, dy: -8).contains(point) }
     func move(by delta: CGPoint) { rect.origin.x += delta.x; rect.origin.y += delta.y }
+    func copy() -> any AnnotationObject {
+        let annotation = EllipseAnnotation(rect: rect)
+        annotation.color = color
+        annotation.lineWidth = lineWidth
+        annotation.isSelected = isSelected
+        return annotation
+    }
 }
 
 // MARK: – Line
@@ -236,6 +259,14 @@ final class LineAnnotation: AnnotationObject {
         startPoint.x += delta.x; startPoint.y += delta.y
         endPoint.x += delta.x;   endPoint.y += delta.y
     }
+
+    func copy() -> any AnnotationObject {
+        let annotation = LineAnnotation(start: startPoint, end: endPoint)
+        annotation.color = color
+        annotation.lineWidth = lineWidth
+        annotation.isSelected = isSelected
+        return annotation
+    }
 }
 
 // MARK: – Freehand
@@ -274,6 +305,14 @@ final class FreehandAnnotation: AnnotationObject {
 
     func contains(point: CGPoint) -> Bool { bounds.insetBy(dx: -8, dy: -8).contains(point) }
     func move(by delta: CGPoint) { points = points.map { CGPoint(x: $0.x+delta.x, y: $0.y+delta.y) } }
+    func copy() -> any AnnotationObject {
+        let annotation = FreehandAnnotation()
+        annotation.color = color
+        annotation.lineWidth = lineWidth
+        annotation.isSelected = isSelected
+        annotation.points = points
+        return annotation
+    }
 }
 
 // MARK: – Highlighter
@@ -314,6 +353,14 @@ final class HighlighterAnnotation: AnnotationObject {
         startPoint.x += delta.x; startPoint.y += delta.y
         endPoint.x += delta.x;   endPoint.y += delta.y
     }
+
+    func copy() -> any AnnotationObject {
+        let annotation = HighlighterAnnotation(start: startPoint, end: endPoint)
+        annotation.color = color
+        annotation.lineWidth = lineWidth
+        annotation.isSelected = isSelected
+        return annotation
+    }
 }
 
 // MARK: – Blur
@@ -338,6 +385,14 @@ final class BlurAnnotation: AnnotationObject {
 
     func contains(point: CGPoint) -> Bool { rect.insetBy(dx: -8, dy: -8).contains(point) }
     func move(by delta: CGPoint) { rect.origin.x += delta.x; rect.origin.y += delta.y }
+    func copy() -> any AnnotationObject {
+        let annotation = BlurAnnotation(rect: rect)
+        annotation.color = color
+        annotation.lineWidth = lineWidth
+        annotation.isSelected = isSelected
+        annotation.radius = radius
+        return annotation
+    }
 }
 
 // MARK: – Pixelate
@@ -362,6 +417,14 @@ final class PixelateAnnotation: AnnotationObject {
 
     func contains(point: CGPoint) -> Bool { rect.insetBy(dx: -8, dy: -8).contains(point) }
     func move(by delta: CGPoint) { rect.origin.x += delta.x; rect.origin.y += delta.y }
+    func copy() -> any AnnotationObject {
+        let annotation = PixelateAnnotation(rect: rect)
+        annotation.color = color
+        annotation.lineWidth = lineWidth
+        annotation.isSelected = isSelected
+        annotation.scale = scale
+        return annotation
+    }
 }
 
 // MARK: – Text
@@ -398,6 +461,15 @@ final class TextAnnotation: AnnotationObject {
 
     func contains(point: CGPoint) -> Bool { bounds.insetBy(dx: -8, dy: -8).contains(point) }
     func move(by delta: CGPoint) { origin.x += delta.x; origin.y += delta.y }
+    func copy() -> any AnnotationObject {
+        let annotation = TextAnnotation(origin: origin)
+        annotation.color = color
+        annotation.lineWidth = lineWidth
+        annotation.isSelected = isSelected
+        annotation.text = text
+        annotation.fontSize = fontSize
+        return annotation
+    }
 }
 
 // MARK: – Numbered Step
@@ -440,6 +512,15 @@ final class NumberedStepAnnotation: AnnotationObject {
     func move(by delta: CGPoint) {
         origin.x += delta.x
         origin.y += delta.y
+    }
+
+    func copy() -> any AnnotationObject {
+        let annotation = NumberedStepAnnotation(center: origin, number: number)
+        annotation.color = color
+        annotation.lineWidth = lineWidth
+        annotation.isSelected = isSelected
+        annotation.diameter = diameter
+        return annotation
     }
 
     func draw(in ctx: CGContext, scale: CGFloat) {

--- a/Sources/Shotnix/App/PreferencesWindowController.swift
+++ b/Sources/Shotnix/App/PreferencesWindowController.swift
@@ -154,7 +154,7 @@ struct ShortcutsSettingsView: View {
             Section {
                 ShortcutRow(title: "Capture Area", key: "⌘⇧4")
                 ShortcutRow(title: "Capture Window", key: "⌘⇧5")
-                ShortcutRow(title: "Capture Fullscreen", key: "⌘⇧6")
+                ShortcutRow(title: "Capture Fullscreen", key: "⌘⇧3 / ⌘⇧6")
                 ShortcutRow(title: "Capture Previous Area", key: "⌘⇧7")
             } header: {
                 Text("Screenshots")
@@ -259,7 +259,7 @@ struct ScreenshotsSettingsView: View {
     }
 }
 struct AboutSettingsView: View {
-    let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.9.2-beta"
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.9.6-beta"
     
     var body: some View {
         VStack(alignment: .center, spacing: 16) {
@@ -284,6 +284,18 @@ struct AboutSettingsView: View {
                 
                 ScrollView {
                     Text("""
+                    Version 0.9.6-beta
+                    • ⌘⇧3 fullscreen capture alias
+                    • Fixed annotation move undo correctness
+                    • Hide desktop icons while capturing now works during capture flows
+                    • Safer WebP fallback and release signing cleanup
+                    • Performance polish for annotation, overlay, history, and scrolling capture
+
+                    Version 0.9.5-beta
+                    • Premium branding, app icon, menu bar icon, and first-launch welcome screen
+                    • Adaptive colors and haptic feedback
+                    • Premium DMG installer branding
+
                     Version 0.9.2-beta
                     • WebP export support (macOS 14+)
                     • First-launch onboarding with permission guide
@@ -307,7 +319,7 @@ struct AboutSettingsView: View {
                     • Quick access overlay with drag-and-drop
                     • Pin screenshots to desktop
                     • Capture history with grid browser
-                    • Global hotkeys (⌘⇧4/5/6/7)
+                    • Global hotkeys (⌘⇧3/4/5/6/7)
                     • Launch at login support
                     • Full settings window
                     """)

--- a/Sources/Shotnix/Capture/AreaSelectionWindow.swift
+++ b/Sources/Shotnix/Capture/AreaSelectionWindow.swift
@@ -154,6 +154,8 @@ private final class SelectionOverlayView: NSView {
     // For window mode
     private var highlightedWindowRect: NSRect?
     private var trackingArea: NSTrackingArea?
+    private var cachedWindowRects: [NSRect] = []
+    private var lastWindowListRefresh: TimeInterval = 0
 
     private let frozenImage: CGImage?
 
@@ -569,8 +571,11 @@ private final class SelectionOverlayView: NSView {
 
     override func mouseMoved(with event: NSEvent) {
         if mode == .window {
+            let previous = highlightedWindowRect
             highlightedWindowRect = windowRect(under: event.locationInWindow)
-            setNeedsDisplay(bounds)
+            if previous != highlightedWindowRect {
+                invalidateWindowHighlight(from: previous, to: highlightedWindowRect)
+            }
         } else if mode == .area && !isSelecting {
             // Invalidate every artifact we paint around the cursor at both
             // the previous and new positions: crosshair strips (full-screen
@@ -584,6 +589,16 @@ private final class SelectionOverlayView: NSView {
             invalidateCursorArtifacts(at: mousePosition!)
         } else {
             setNeedsDisplay(bounds)
+        }
+    }
+
+    private func invalidateWindowHighlight(from oldRect: NSRect?, to newRect: NSRect?) {
+        let padding: CGFloat = 8
+        if let oldRect {
+            setNeedsDisplay(oldRect.insetBy(dx: -padding, dy: -padding).intersection(bounds))
+        }
+        if let newRect {
+            setNeedsDisplay(newRect.insetBy(dx: -padding, dy: -padding).intersection(bounds))
         }
     }
 
@@ -630,34 +645,38 @@ private final class SelectionOverlayView: NSView {
     private func windowRect(under point: NSPoint) -> NSRect? {
         guard let win = window else { return nil }
         let screenPoint = win.convertToScreen(NSRect(origin: point, size: .zero)).origin
+        refreshWindowRectsIfNeeded()
+        for appKitRect in cachedWindowRects where appKitRect.contains(screenPoint) {
+            let viewOrigin = win.convertFromScreen(NSRect(origin: appKitRect.origin, size: .zero)).origin
+            return NSRect(origin: viewOrigin, size: appKitRect.size)
+        }
+        return nil
+    }
+
+    private func refreshWindowRectsIfNeeded() {
+        let now = ProcessInfo.processInfo.systemUptime
+        guard now - lastWindowListRefresh > 0.15 else { return }
+        lastWindowListRefresh = now
         let windowList = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) as? [[String: Any]] ?? []
-        for info in windowList {
+        let screenHeight = NSScreen.screens.first?.frame.height ?? 0
+        cachedWindowRects = windowList.compactMap { info in
             guard
                 let layer = info[kCGWindowLayer as String] as? Int, layer == 0,
                 let boundsDict = info[kCGWindowBounds as String] as? [String: CGFloat]
-            else { continue }
+            else { return nil }
             let bounds = CGRect(
                 x: boundsDict["X"] ?? 0,
                 y: boundsDict["Y"] ?? 0,
                 width: boundsDict["Width"] ?? 0,
                 height: boundsDict["Height"] ?? 0
             )
-            // CGWindowBounds uses top-left origin (CG global coords); convert to AppKit bottom-left.
-            // The CG origin is anchored to the primary display — use screens[0], NOT .main
-            // (.main returns the key screen, which may be a secondary with different height).
-            let screenHeight = NSScreen.screens.first?.frame.height ?? 0
-            let appKitRect = CGRect(
+            return CGRect(
                 x: bounds.origin.x,
                 y: screenHeight - bounds.origin.y - bounds.height,
                 width: bounds.width,
                 height: bounds.height
             )
-            if appKitRect.contains(screenPoint) {
-                // Convert back to view coords for display
-                let viewOrigin = win.convertFromScreen(NSRect(origin: appKitRect.origin, size: .zero)).origin
-                return NSRect(origin: viewOrigin, size: appKitRect.size)
-            }
         }
-        return nil
     }
+
 }

--- a/Sources/Shotnix/Capture/CaptureEngine.swift
+++ b/Sources/Shotnix/Capture/CaptureEngine.swift
@@ -11,6 +11,19 @@ final class CaptureEngine {
     private var areaSelectionWindow: AreaSelectionWindow?
     private var scrollingCapture: ScrollingCaptureController?
 
+    private func hideDesktopIconsForCaptureIfNeeded() async -> Bool {
+        guard Settings.hideDesktopIconsWhileCapturing else { return false }
+        let hiddenByCapture = DesktopIconsManager.hideForCapture()
+        if hiddenByCapture {
+            try? await Task.sleep(nanoseconds: 350_000_000)
+        }
+        return hiddenByCapture
+    }
+
+    private func restoreDesktopIconsIfNeeded(_ hiddenByCapture: Bool) {
+        DesktopIconsManager.showAfterCapture(ifHiddenByCapture: hiddenByCapture)
+    }
+
     // Cached SCShareableContent. `SCShareableContent.excludingDesktopWindows`
     // enumerates every on-screen window and routinely costs 30–100 ms. For
     // area/fullscreen/previous capture modes we only need the display list, and
@@ -66,12 +79,19 @@ final class CaptureEngine {
             PermissionsManager.showPermissionDeniedAlert(); return
         }
         guard areaSelectionWindow == nil else { return } // already selecting
+        let hiddenByCapture = await hideDesktopIconsForCaptureIfNeeded()
         areaSelectionWindow = AreaSelectionWindow(mode: .area) { [weak self] rect, screen in
             guard let self else { return }
             self.areaSelectionWindow = nil
-            guard let rect else { return }
+            guard let rect else {
+                self.restoreDesktopIconsIfNeeded(hiddenByCapture)
+                return
+            }
             self.lastCaptureRect = rect
-            Task { await self.captureRect(rect, on: screen, historyManager: historyManager) }
+            Task {
+                await self.captureRect(rect, on: screen, historyManager: historyManager)
+                self.restoreDesktopIconsIfNeeded(hiddenByCapture)
+            }
         }
         await areaSelectionWindow?.prepareAndShow(engine: self)
     }
@@ -83,11 +103,18 @@ final class CaptureEngine {
             PermissionsManager.showPermissionDeniedAlert(); return
         }
         guard areaSelectionWindow == nil else { return }
+        let hiddenByCapture = await hideDesktopIconsForCaptureIfNeeded()
         areaSelectionWindow = AreaSelectionWindow(mode: .window) { [weak self] rect, screen in
             guard let self else { return }
             self.areaSelectionWindow = nil
-            guard let rect else { return }
-            Task { await self.captureRect(rect, on: screen, historyManager: historyManager) }
+            guard let rect else {
+                self.restoreDesktopIconsIfNeeded(hiddenByCapture)
+                return
+            }
+            Task {
+                await self.captureRect(rect, on: screen, historyManager: historyManager)
+                self.restoreDesktopIconsIfNeeded(hiddenByCapture)
+            }
         }
         await areaSelectionWindow?.prepareAndShow(engine: self)
     }
@@ -100,6 +127,8 @@ final class CaptureEngine {
         }
         let screens = NSScreen.screens
         guard !screens.isEmpty else { return }
+        let hiddenByCapture = await hideDesktopIconsForCaptureIfNeeded()
+        defer { restoreDesktopIconsIfNeeded(hiddenByCapture) }
         // Capture the main (key) screen
         let screen = NSScreen.main ?? screens[0]
         let rect = screen.frame
@@ -116,6 +145,8 @@ final class CaptureEngine {
         guard let screen = NSScreen.screens.first(where: { $0.frame.intersects(rect) }) ?? NSScreen.main else {
             await startAreaCapture(historyManager: historyManager); return
         }
+        let hiddenByCapture = await hideDesktopIconsForCaptureIfNeeded()
+        defer { restoreDesktopIconsIfNeeded(hiddenByCapture) }
         await captureRect(rect, on: screen, historyManager: historyManager)
     }
 
@@ -125,8 +156,9 @@ final class CaptureEngine {
         guard PermissionsManager.hasScreenRecordingPermission else {
             PermissionsManager.showPermissionDeniedAlert(); return
         }
+        guard scrollingCapture?.isActive != true else { return }
         scrollingCapture = ScrollingCaptureController()
-        await scrollingCapture?.start(historyManager: historyManager)
+        await scrollingCapture?.start(historyManager: historyManager, hiddenDesktopIconsByCapture: await hideDesktopIconsForCaptureIfNeeded())
     }
 
     // MARK: – OCR Capture
@@ -136,18 +168,26 @@ final class CaptureEngine {
             PermissionsManager.showPermissionDeniedAlert(); return
         }
         guard areaSelectionWindow == nil else { return }
+        let hiddenByCapture = await hideDesktopIconsForCaptureIfNeeded()
         areaSelectionWindow = AreaSelectionWindow(mode: .area) { [weak self] rect, screen in
             guard let self else { return }
             self.areaSelectionWindow = nil
-            guard let rect else { return }
+            guard let rect else {
+                self.restoreDesktopIconsIfNeeded(hiddenByCapture)
+                return
+            }
             Task {
-                guard let image = await self.captureRectToImage(rect, on: screen) else { return }
+                guard let image = await self.captureRectToImage(rect, on: screen) else {
+                    self.restoreDesktopIconsIfNeeded(hiddenByCapture)
+                    return
+                }
                 let text = await OCREngine.recognizeText(in: image)
                 await MainActor.run {
                     NSPasteboard.general.clearContents()
                     NSPasteboard.general.setString(text, forType: .string)
                     self.showOCRNotification(text: text)
                 }
+                self.restoreDesktopIconsIfNeeded(hiddenByCapture)
             }
         }
         await areaSelectionWindow?.prepareAndShow(engine: self)

--- a/Sources/Shotnix/Capture/ScrollingCaptureController.swift
+++ b/Sources/Shotnix/Capture/ScrollingCaptureController.swift
@@ -10,19 +10,35 @@ final class ScrollingCaptureController: NSObject {
     private var captureScreen: NSScreen?
     private var frames: [NSImage] = []
     private var isCapturing = false
+    private var isCapturingFrame = false
     private var captureTimer: Timer?
     private var statusWindow: ScrollingStatusWindow?
+    private var hiddenDesktopIconsByCapture = false
+    private var pendingStopHistoryManager: HistoryManager?
     /// Single reusable capture engine — never allocate per-frame
     private let captureEngine = CaptureEngine()
 
-    func start(historyManager: HistoryManager) async {
+    var isActive: Bool { isCapturing || selectionWindow != nil }
+
+    deinit {
+        captureTimer?.invalidate()
+    }
+
+    func start(historyManager: HistoryManager, hiddenDesktopIconsByCapture: Bool = false) async {
+        self.hiddenDesktopIconsByCapture = hiddenDesktopIconsByCapture
         selectionWindow = AreaSelectionWindow(mode: .area) { [weak self] rect, screen in
-            guard let self, let rect else { return }
+            guard let self else { return }
+            self.selectionWindow = nil
+            guard let rect else {
+                DesktopIconsManager.showAfterCapture(ifHiddenByCapture: self.hiddenDesktopIconsByCapture)
+                self.hiddenDesktopIconsByCapture = false
+                return
+            }
             self.captureRect = rect
             self.captureScreen = screen
             self.beginScrollingPhase(historyManager: historyManager)
         }
-        await selectionWindow?.prepareAndShow(engine: CaptureEngine())
+        await selectionWindow?.prepareAndShow(engine: captureEngine)
     }
 
     private func beginScrollingPhase(historyManager: HistoryManager) {
@@ -47,10 +63,17 @@ final class ScrollingCaptureController: NSObject {
 
     private func captureFrame() {
         guard isCapturing, let rect = captureRect, let screen = captureScreen else { return }
+        guard !isCapturingFrame else { return }
+        isCapturingFrame = true
         Task {
             if let img = await captureEngine.captureRectToImage(rect, on: screen) {
                 self.frames.append(img)
                 self.statusWindow?.updateCount(self.frames.count)
+            }
+            self.isCapturingFrame = false
+            if let historyManager = self.pendingStopHistoryManager {
+                self.pendingStopHistoryManager = nil
+                self.finishCapture(historyManager: historyManager)
             }
         }
     }
@@ -59,16 +82,39 @@ final class ScrollingCaptureController: NSObject {
         captureTimer?.invalidate()
         captureTimer = nil
         isCapturing = false
+
+        if isCapturingFrame {
+            pendingStopHistoryManager = historyManager
+            return
+        }
+
+        finishCapture(historyManager: historyManager)
+    }
+
+    private func finishCapture(historyManager: HistoryManager) {
+        captureTimer?.invalidate()
+        captureTimer = nil
+        isCapturing = false
+        isCapturingFrame = false
+        selectionWindow = nil
         statusWindow?.orderOut(nil)
         statusWindow = nil
+        let shouldRestoreDesktopIcons = hiddenDesktopIconsByCapture
+        hiddenDesktopIconsByCapture = false
 
-        guard !frames.isEmpty else { return }
+        guard !frames.isEmpty else {
+            DesktopIconsManager.showAfterCapture(ifHiddenByCapture: shouldRestoreDesktopIcons)
+            return
+        }
         let framesToStitch = frames
         let rect = captureRect ?? .zero
         Task.detached(priority: .userInitiated) {
             let stitched = FrameStitcher.stitch(frames: framesToStitch)
             await MainActor.run { [weak self] in
-                guard self != nil else { return }
+                guard self != nil else {
+                    DesktopIconsManager.showAfterCapture(ifHiddenByCapture: shouldRestoreDesktopIcons)
+                    return
+                }
                 let item = historyManager.add(image: stitched, rect: rect)
 
                 if Settings.afterCaptureCopyToClipboard {
@@ -84,6 +130,7 @@ final class ScrollingCaptureController: NSObject {
                 if Settings.afterCaptureShowOverlay {
                     QuickAccessOverlay.show(image: stitched, historyItem: item, historyManager: historyManager)
                 }
+                DesktopIconsManager.showAfterCapture(ifHiddenByCapture: shouldRestoreDesktopIcons)
             }
         }
     }

--- a/Sources/Shotnix/History/HistoryPanelController.swift
+++ b/Sources/Shotnix/History/HistoryPanelController.swift
@@ -10,6 +10,7 @@ final class HistoryPanelController: NSObject {
     private weak var historyManager: HistoryManager?
     private var collectionView: NSCollectionView?
     private var emptyOverlay: NSView?
+    private var closeObserver: NSObjectProtocol?
 
     private struct Section {
         let title: String
@@ -31,10 +32,6 @@ final class HistoryPanelController: NSObject {
             updateEmptyState()
             return
         }
-        NotificationCenter.default.addObserver(
-            self, selector: #selector(panelDidClose),
-            name: NSWindow.willCloseNotification, object: nil
-        )
         let p = NSPanel(
             contentRect: NSRect(x: 0, y: 0, width: 600, height: 480),
             styleMask: [.titled, .closable, .resizable, .utilityWindow],
@@ -46,6 +43,13 @@ final class HistoryPanelController: NSObject {
         p.center()
         p.contentView = buildContent(historyManager: historyManager)
         p.alphaValue = 0
+        closeObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: p,
+            queue: .main
+        ) { [weak self] notification in
+            Task { @MainActor in self?.panelDidClose(notification) }
+        }
         p.makeKeyAndOrderFront(nil)
         NSAnimationContext.runAnimationGroup { ctx in
             ctx.duration = 0.2
@@ -210,6 +214,10 @@ final class HistoryPanelController: NSObject {
 
     @objc private func panelDidClose(_ notification: Notification) {
         guard let closedWindow = notification.object as? NSWindow, closedWindow === panel else { return }
+        if let closeObserver {
+            NotificationCenter.default.removeObserver(closeObserver)
+            self.closeObserver = nil
+        }
         panel = nil
         collectionView = nil
         emptyOverlay = nil

--- a/Sources/Shotnix/Hotkeys/HotkeyManager.swift
+++ b/Sources/Shotnix/Hotkeys/HotkeyManager.swift
@@ -24,7 +24,15 @@ final class HotkeyManager {
         }
         hotkeys.append(win)
 
-        // ⌘⇧6 — Capture Fullscreen
+        // ⌘⇧3 — Capture Fullscreen (macOS muscle memory; requires native shortcut disabled)
+        let fullNative = HotKey(key: .three, modifiers: [.command, .shift])
+        fullNative.keyDownHandler = { [weak captureEngine, weak historyManager] in
+            guard let e = captureEngine, let h = historyManager else { return }
+            Task { await e.captureFullscreen(historyManager: h) }
+        }
+        hotkeys.append(fullNative)
+
+        // ⌘⇧6 — Capture Fullscreen (non-conflicting fallback)
         let full = HotKey(key: .six, modifiers: [.command, .shift])
         full.keyDownHandler = { [weak captureEngine, weak historyManager] in
             guard let e = captureEngine, let h = historyManager else { return }

--- a/Sources/Shotnix/OCR/OCREngine.swift
+++ b/Sources/Shotnix/OCR/OCREngine.swift
@@ -5,7 +5,7 @@ enum OCREngine {
 
     /// Recognize text in a CGImage and return the full recognized string.
     static func recognizeText(in image: NSImage) async -> String {
-        guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else { return "" }
+        guard let cgImage = image.bestCGImage else { return "" }
         return await recognizeText(in: cgImage)
     }
 

--- a/Sources/Shotnix/Overlay/QuickAccessOverlay.swift
+++ b/Sources/Shotnix/Overlay/QuickAccessOverlay.swift
@@ -27,7 +27,9 @@ private final class QuickAccessWindow: NSWindow {
     private let historyManager: HistoryManager
     private let image: NSImage
     private var controlsOverlay: NSView?
+    private weak var timeoutProgressLayer: CALayer?
     private var isHovered = false
+    private var mouseInsideOverlay = false
     private var swipeAccumX: CGFloat = 0
 
     init(image: NSImage, historyItem: HistoryItem, historyManager: HistoryManager) {
@@ -105,6 +107,8 @@ private final class QuickAccessWindow: NSWindow {
         globalMouseMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.mouseMoved, .leftMouseDragged]) { [weak self] _ in
             guard let self, !self.isClosing else { return }
             let inside = self.frame.contains(NSEvent.mouseLocation)
+            guard inside != self.mouseInsideOverlay else { return }
+            self.mouseInsideOverlay = inside
             DispatchQueue.main.async {
                 self.setHovered(inside)
                 if inside {
@@ -312,13 +316,12 @@ private final class QuickAccessWindow: NSWindow {
             let progressFill = NSView(frame: progressBg.bounds)
             progressFill.wantsLayer = true
             progressFill.layer?.backgroundColor = NSColor.controlAccentColor.cgColor
+            progressFill.layer?.anchorPoint = CGPoint(x: 0, y: 0.5)
+            progressFill.layer?.position = CGPoint(x: 0, y: progressH / 2)
             progressBg.addSubview(progressFill)
+            timeoutProgressLayer = progressFill.layer
 
-            NSAnimationContext.runAnimationGroup({ ctx in
-                ctx.duration = timeout
-                ctx.timingFunction = CAMediaTimingFunction(name: .linear)
-                progressFill.animator().frame = NSRect(x: 0, y: 0, width: 0, height: progressH)
-            })
+            animateTimeoutProgress(duration: timeout)
 
             dismissTimer = Timer.scheduledTimer(withTimeInterval: timeout, repeats: false) { [weak self] _ in
                 DispatchQueue.main.async { self?.animatedClose() }
@@ -333,9 +336,11 @@ private final class QuickAccessWindow: NSWindow {
         // Pause/resume auto-dismiss timer on hover (like CleanShot X)
         if hovered {
             dismissTimer?.invalidate()
+            timeoutProgressLayer?.removeAnimation(forKey: "timeoutProgress")
         } else {
             let remaining = Settings.overlayTimeout
             if remaining > 0 {
+                animateTimeoutProgress(duration: remaining)
                 dismissTimer = Timer.scheduledTimer(withTimeInterval: remaining, repeats: false) { [weak self] _ in
                     DispatchQueue.main.async { self?.animatedClose() }
                 }
@@ -346,6 +351,20 @@ private final class QuickAccessWindow: NSWindow {
             ctx.duration = 0.2
             controlsOverlay?.animator().alphaValue = hovered ? 1 : 0
         }
+    }
+
+    private func animateTimeoutProgress(duration: TimeInterval) {
+        guard let layer = timeoutProgressLayer else { return }
+        layer.removeAnimation(forKey: "timeoutProgress")
+        layer.transform = CATransform3DIdentity
+        let shrink = CABasicAnimation(keyPath: "transform.scale.x")
+        shrink.fromValue = 1.0
+        shrink.toValue = 0.0
+        shrink.duration = duration
+        shrink.timingFunction = CAMediaTimingFunction(name: .linear)
+        shrink.fillMode = .forwards
+        shrink.isRemovedOnCompletion = false
+        layer.add(shrink, forKey: "timeoutProgress")
     }
 
     private func positionOverlay() {
@@ -617,6 +636,14 @@ private final class DraggableImageView: NSImageView, NSDraggingSource {
 
 private final class ImageFilePromiseDelegate: NSObject, NSFilePromiseProviderDelegate, @unchecked Sendable {
 
+    private static let queue: OperationQueue = {
+        let queue = OperationQueue()
+        queue.name = "Shotnix.FilePromise"
+        queue.maxConcurrentOperationCount = 1
+        queue.qualityOfService = .userInitiated
+        return queue
+    }()
+
     private let image: NSImage
 
     init(image: NSImage) {
@@ -639,7 +666,7 @@ private final class ImageFilePromiseDelegate: NSObject, NSFilePromiseProviderDel
     }
 
     func operationQueue(for filePromiseProvider: NSFilePromiseProvider) -> OperationQueue {
-        .main
+        Self.queue
     }
 }
 

--- a/Sources/Shotnix/Utilities/DesktopIconsManager.swift
+++ b/Sources/Shotnix/Utilities/DesktopIconsManager.swift
@@ -4,9 +4,30 @@ import AppKit
 enum DesktopIconsManager {
 
     private static var isHidden = false
+    private static let finderAppID = "com.apple.finder" as CFString
+    private static let createDesktopKey = "CreateDesktop" as CFString
+
+    static var desktopIconsVisible: Bool {
+        guard let value = CFPreferencesCopyAppValue(createDesktopKey, finderAppID) else { return true }
+        return (value as? Bool) ?? true
+    }
 
     static func toggle() {
-        isHidden ? show() : hide()
+        desktopIconsVisible ? hide() : show()
+    }
+
+    static func hideForCapture() -> Bool {
+        guard desktopIconsVisible else {
+            isHidden = true
+            return false
+        }
+        hide()
+        return true
+    }
+
+    static func showAfterCapture(ifHiddenByCapture hiddenByCapture: Bool) {
+        guard hiddenByCapture else { return }
+        show()
     }
 
     static func hide() {
@@ -21,9 +42,8 @@ enum DesktopIconsManager {
 
     private static func setCreateDesktop(_ value: Bool) {
         // Use native CFPreferences instead of 'defaults write' shell script
-        let appID = "com.apple.finder" as CFString
-        CFPreferencesSetValue("CreateDesktop" as CFString, value as CFPropertyList, appID, kCFPreferencesCurrentUser, kCFPreferencesAnyHost)
-        CFPreferencesSynchronize(appID, kCFPreferencesCurrentUser, kCFPreferencesAnyHost)
+        CFPreferencesSetValue(createDesktopKey, value as CFPropertyList, finderAppID, kCFPreferencesCurrentUser, kCFPreferencesAnyHost)
+        CFPreferencesSynchronize(finderAppID, kCFPreferencesCurrentUser, kCFPreferencesAnyHost)
 
         // Gently restart Finder natively
         if let finder = NSWorkspace.shared.runningApplications.first(where: { $0.bundleIdentifier == "com.apple.finder" }) {

--- a/Sources/Shotnix/Utilities/ImageExporter.swift
+++ b/Sources/Shotnix/Utilities/ImageExporter.swift
@@ -4,6 +4,8 @@ import ImageIO
 
 enum ImageExporter {
 
+    private static let webpUTI = "org.webmproject.webp" as CFString
+
     // MARK: – Clipboard
 
     static func copyToClipboard(image: NSImage) {
@@ -51,16 +53,23 @@ enum ImageExporter {
         // Extract the CGImage once and reuse it for whichever encoder runs.
         guard let cg = image.bestCGImage else { return }
         let ext = url.pathExtension.lowercased()
+        var outputURL = url
         let data: Data?
         switch ext {
-        case "jpg", "jpeg": data = jpegData(from: cg)
-        case "webp":        data = webpData(from: cg)
+        case "jpg", "jpeg": data = jpegData(from: cg, quality: CGFloat(Settings.jpegQuality))
+        case "webp":
+            if isWebPSupported, let webp = webpData(from: cg) {
+                data = webp
+            } else {
+                outputURL = url.deletingPathExtension().appendingPathExtension("png")
+                data = pngData(from: cg)
+            }
         default:            data = pngData(from: cg)
         }
-        let dir = url.deletingLastPathComponent()
+        let dir = outputURL.deletingLastPathComponent()
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        try? data?.write(to: url)
-        HistoryManager.applyScreenshotMetadata(to: url.path, rect: nil)
+        try? data?.write(to: outputURL)
+        HistoryManager.applyScreenshotMetadata(to: outputURL.path, rect: nil)
     }
 
     // MARK: – Format helpers
@@ -87,15 +96,20 @@ enum ImageExporter {
     }
 
     static func webpData(from cg: CGImage, quality: CGFloat = 0.90) -> Data? {
+        guard isWebPSupported else { return nil }
         let data = NSMutableData()
-        let webpUTI = "org.webmproject.webp" as CFString
         guard let dest = CGImageDestinationCreateWithData(data, webpUTI, 1, nil) else {
-            return pngData(from: cg)
+            return nil
         }
         let opts: [CFString: Any] = [kCGImageDestinationLossyCompressionQuality: quality]
         CGImageDestinationAddImage(dest, cg, opts as CFDictionary)
-        guard CGImageDestinationFinalize(dest) else { return pngData(from: cg) }
+        guard CGImageDestinationFinalize(dest) else { return nil }
         return data as Data
+    }
+
+    private static var isWebPSupported: Bool {
+        let identifiers = CGImageDestinationCopyTypeIdentifiers() as NSArray
+        return identifiers.contains(webpUTI)
     }
 
     static func pngData(from image: NSImage) -> Data? {

--- a/build-app.sh
+++ b/build-app.sh
@@ -4,7 +4,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 APP_NAME="Shotnix"
 APP_BUNDLE="$SCRIPT_DIR/$APP_NAME.app"
-DEST="$HOME/Desktop/$APP_NAME.app"
+ENTITLEMENTS="$SCRIPT_DIR/Shotnix.entitlements"
 
 echo "▶ Building $APP_NAME (release)…"
 cd "$SCRIPT_DIR"
@@ -29,32 +29,16 @@ if [ -f "$SCRIPT_DIR/Branding/Shotnix.icns" ]; then
     cp "$SCRIPT_DIR/Branding/Shotnix.icns" "$APP_BUNDLE/Contents/Resources/Shotnix.icns"
 fi
 
-# Write entitlements for ScreenCaptureKit
-cat > /tmp/Shotnix.entitlements <<'ENTITLEMENTS'
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>com.apple.security.app-sandbox</key>
-    <false/>
-    <key>com.apple.security.cs.allow-jit</key>
-    <false/>
-</dict>
-</plist>
-ENTITLEMENTS
-
 echo "▶ Ad-hoc signing…"
 codesign --force --deep --sign - \
-    --entitlements /tmp/Shotnix.entitlements \
+    --options runtime \
+    --entitlements "$ENTITLEMENTS" \
     "$APP_BUNDLE"
 
 echo "▶ Copying to /Applications…"
 APPS_DEST="/Applications/$APP_NAME.app"
 rm -rf "$APPS_DEST"
 cp -R "$APP_BUNDLE" "$APPS_DEST"
-
-# Remove quarantine so it opens without Gatekeeper prompt
-xattr -dr com.apple.quarantine "$APPS_DEST" 2>/dev/null || true
 
 echo ""
 echo "✓ Done!  Shotnix.app deployed to /Applications."


### PR DESCRIPTION
## Summary
- Improves capture smoothness by throttling window hit-testing, preventing overlapping scrolling frames, and reducing overlay/annotation main-thread churn.
- Fixes capture correctness issues around desktop icon restoration, annotation move undo snapshots, OCR image extraction, and WebP fallback output.
- Bumps release metadata to v0.9.6-beta and updates signing to use a committed entitlements file with hardened runtime options.

## Verification
- swift build
- bash build-app.sh
- codesign --verify --deep --strict /Applications/Shotnix.app
- open -a /Applications/Shotnix.app

Known warning: AreaSelectionWindow.swift still reports NSScreen Sendable warnings under future Swift 6 language mode; no errors.