### PR TITLE
Release v0.9.7-beta — window lifecycle & annotation polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.9.7-beta] - 2026-05-01
+
+### Fixed
+- **Cmd-Tab visibility** — closing a Shotnix window no longer prematurely drops the app from Cmd-Tab when other Shotnix windows are still open. Replaced hardcoded `NSApp.setActivationPolicy(.prohibited)` calls across the annotation editor, preferences, welcome, history, pinned-window, area-selection, quick-access overlay, and shortcut-permission flows with a centralized helper that only restores background-only mode when no Shotnix windows remain.
+- **Annotation editor layout** — the toolbar now reserves space for the macOS traffic-light buttons and enforces a minimum window width, so close/minimize/zoom no longer overlap toolbar controls.
+- **Arrow rendering** — arrow shafts now stop short of the arrowhead by half the line width, removing the visible bulge at the tip on thick strokes.
+
+### Changed
+- **Multi-screen area capture** — simplified the per-screen freeze-frame capture loop (sequential capture in place of a `TaskGroup`); behavior unchanged but code is easier to follow.
+
+### Internal
+- New `ActivationPolicy.swift` helper extends `NSApplication` with `restoreBackgroundOnlyActivationPolicyIfNeeded(excluding:)`, the single source of truth for menu-bar-app activation lifecycle.
+
 ## [0.9.6-beta] - 2026-04-29
 
 ### Added

--- a/Info.plist
+++ b/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleDisplayName</key>
     <string>Shotnix</string>
     <key>CFBundleVersion</key>
-    <string>7</string>
+    <string>8</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.6-beta</string>
+    <string>0.9.7-beta</string>
     <key>CFBundleExecutable</key>
     <string>Shotnix</string>
     <key>CFBundlePackageType</key>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ---
 
 > [!NOTE]
-> **Shotnix is in beta (v0.9.6).** It's fully functional but not yet notarized through Apple's Developer Program, so macOS will show a Gatekeeper warning on first launch. This is standard for open-source apps — Shotnix is safe and the source code is right here. Notarization is on the roadmap.
+> **Shotnix is in beta (v0.9.7).** It's fully functional but not yet notarized through Apple's Developer Program, so macOS will show a Gatekeeper warning on first launch. This is standard for open-source apps — Shotnix is safe and the source code is right here. Notarization is on the roadmap.
 >
 > To open: **Right-click → Open → Open** (macOS 13–14) or **System Settings → Privacy & Security → Open Anyway** (macOS 15+).
 

--- a/Sources/Shotnix/Annotation/AnnotationObject.swift
+++ b/Sources/Shotnix/Annotation/AnnotationObject.swift
@@ -82,17 +82,28 @@ final class ArrowAnnotation: AnnotationObject {
     }
 
     func draw(in ctx: CGContext, scale: CGFloat) {
+        let dx = endPoint.x - startPoint.x
+        let dy = endPoint.y - startPoint.y
+        let length = hypot(dx, dy)
+        guard length > 0 else { return }
+
+        let unitX = dx / length
+        let unitY = dy / length
+        let shaftEnd = CGPoint(
+            x: endPoint.x - unitX * (lineWidth / 2),
+            y: endPoint.y - unitY * (lineWidth / 2)
+        )
+
         ctx.saveGState()
         ctx.setStrokeColor(color.cgColor)
         ctx.setLineWidth(lineWidth)
         ctx.setLineCap(.round)
 
         ctx.move(to: startPoint)
-        ctx.addLine(to: endPoint)
+        ctx.addLine(to: shaftEnd)
         ctx.strokePath()
 
-        // Arrowhead
-        let angle = atan2(endPoint.y - startPoint.y, endPoint.x - startPoint.x)
+        let angle = atan2(dy, dx)
         let arrowLen: CGFloat = lineWidth * 5
         let arrowAngle: CGFloat = .pi / 6
         let p1 = CGPoint(

--- a/Sources/Shotnix/Annotation/AnnotationWindowController.swift
+++ b/Sources/Shotnix/Annotation/AnnotationWindowController.swift
@@ -4,6 +4,9 @@ import AppKit
 @MainActor
 final class AnnotationWindowController: NSWindowController {
 
+    private static let trafficLightReservedWidth: CGFloat = 92
+    private static let minimumEditorWidth = trafficLightReservedWidth + AnnotationToolbar.requiredWidth
+
     private let canvas: AnnotationCanvas
     private let toolbar: AnnotationToolbar
     private let historyItem: HistoryItem?
@@ -44,7 +47,7 @@ final class AnnotationWindowController: NSWindowController {
         let screenFrame = NSScreen.main?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1280, height: 800)
         let maxW = screenFrame.width * 0.85
         let maxH = screenFrame.height * 0.85 - toolbarHeight
-        let winW = min(canvasSize.width, maxW)
+        let winW = max(min(canvasSize.width, maxW), Self.minimumEditorWidth)
         let winH = min(canvasSize.height, maxH) + toolbarHeight
         let windowSize = NSSize(width: winW, height: winH)
 
@@ -57,7 +60,7 @@ final class AnnotationWindowController: NSWindowController {
         win.titleVisibility = .hidden
         win.titlebarAppearsTransparent = true
         win.isReleasedWhenClosed = false
-        win.minSize = NSSize(width: 320, height: 240 + toolbarHeight)
+        win.minSize = NSSize(width: Self.minimumEditorWidth, height: 240 + toolbarHeight)
         win.center()
 
         super.init(window: win)
@@ -82,7 +85,12 @@ final class AnnotationWindowController: NSWindowController {
         scrollView.verticalScrollElasticity = .none
 
         // Toolbar positioned at top of window
-        toolbar.frame = NSRect(x: 0, y: winH - toolbarHeight, width: winW, height: toolbarHeight)
+        toolbar.frame = NSRect(
+            x: Self.trafficLightReservedWidth,
+            y: winH - toolbarHeight,
+            width: max(0, winW - Self.trafficLightReservedWidth),
+            height: toolbarHeight
+        )
         toolbar.autoresizingMask = [.width, .minYMargin]
 
         toolbar.onToolChanged     = { [weak self] tool in
@@ -186,7 +194,7 @@ extension AnnotationWindowController: NSWindowDelegate {
     func windowWillClose(_ notification: Notification) {
         AnnotationWindowController.openControllers.removeAll { $0 === self }
         if AnnotationWindowController.openControllers.isEmpty {
-            NSApp.setActivationPolicy(.prohibited)
+            NSApp.restoreBackgroundOnlyActivationPolicyIfNeeded(excluding: notification.object as? NSWindow)
         }
     }
 }
@@ -214,6 +222,8 @@ final class CenteringClipView: NSClipView {
 
 @MainActor
 final class AnnotationToolbar: NSView {
+
+    static let requiredWidth: CGFloat = 870
 
     var onToolChanged: ((AnnotationTool) -> Void)?
     var onColorChanged: ((NSColor) -> Void)?

--- a/Sources/Shotnix/App/ActivationPolicy.swift
+++ b/Sources/Shotnix/App/ActivationPolicy.swift
@@ -1,0 +1,31 @@
+import AppKit
+
+@MainActor
+extension NSApplication {
+    func restoreBackgroundOnlyActivationPolicyIfNeeded(excluding closingWindow: NSWindow? = nil) {
+        guard !hasVisiblePersistentWindow(excluding: closingWindow) else {
+            return
+        }
+
+        setActivationPolicy(.prohibited)
+    }
+
+    private func hasVisiblePersistentWindow(excluding closingWindow: NSWindow?) -> Bool {
+        windows.contains { window in
+            if let closingWindow, window === closingWindow {
+                return false
+            }
+
+            guard window.isVisible, !window.isMiniaturized else {
+                return false
+            }
+
+            if window is PinnedWindow {
+                return true
+            }
+
+            let persistentMasks: NSWindow.StyleMask = [.titled, .closable, .resizable, .miniaturizable]
+            return !window.styleMask.intersection(persistentMasks).isEmpty
+        }
+    }
+}

--- a/Sources/Shotnix/App/PreferencesWindowController.swift
+++ b/Sources/Shotnix/App/PreferencesWindowController.swift
@@ -72,7 +72,7 @@ final class PreferencesWindowController: NSWindowController, NSWindowDelegate {
     }
     
     func windowWillClose(_ notification: Notification) {
-        NSApp.setActivationPolicy(.prohibited)
+        NSApp.restoreBackgroundOnlyActivationPolicyIfNeeded(excluding: notification.object as? NSWindow)
     }
 }
 
@@ -259,7 +259,7 @@ struct ScreenshotsSettingsView: View {
     }
 }
 struct AboutSettingsView: View {
-        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.9.6-beta"
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.9.7-beta"
     
     var body: some View {
         VStack(alignment: .center, spacing: 16) {
@@ -284,6 +284,11 @@ struct AboutSettingsView: View {
                 
                 ScrollView {
                     Text("""
+                    Version 0.9.7-beta
+                    • Closing a Shotnix window no longer drops the app from Cmd-Tab when other windows remain open
+                    • Annotation editor toolbar no longer overlaps the traffic light buttons
+                    • Arrow annotations render cleanly — shaft now stops at the arrowhead instead of overlapping it
+
                     Version 0.9.6-beta
                     • ⌘⇧3 fullscreen capture alias
                     • Fixed annotation move undo correctness

--- a/Sources/Shotnix/App/WelcomeWindowController.swift
+++ b/Sources/Shotnix/App/WelcomeWindowController.swift
@@ -123,6 +123,6 @@ final class WelcomeWindowController: NSObject, NSWindowDelegate {
 
     func windowWillClose(_ notification: Notification) {
         window = nil
-        NSApp.setActivationPolicy(.prohibited)
+        NSApp.restoreBackgroundOnlyActivationPolicyIfNeeded(excluding: notification.object as? NSWindow)
     }
 }

--- a/Sources/Shotnix/Capture/AreaSelectionWindow.swift
+++ b/Sources/Shotnix/Capture/AreaSelectionWindow.swift
@@ -26,24 +26,15 @@ final class AreaSelectionWindow: NSObject {
         NSApp.setActivationPolicy(.accessory)
         NSApp.activate(ignoringOtherApps: true)
 
-        // Capture all screens concurrently for speed
-        await withTaskGroup(of: (NSScreen, CGImage?).self) { group in
-            for screen in NSScreen.screens {
-                group.addTask {
-                    let image = await engine.captureRectToImage(screen.frame, on: screen)
-                    var r = NSRect(origin: .zero, size: screen.frame.size)
-                    let cg = image?.cgImage(forProposedRect: &r, context: nil, hints: nil)
-                    return (screen, cg)
-                }
-            }
-            
-            for await (screen, frozenCG) in group {
-                let overlay = SelectionOverlayWindow(screen: screen, mode: self.mode, frozenImage: frozenCG)
-                overlay.selectionHandler = { [weak self] rect in self?.finish(rect: rect, screen: screen) }
-                overlay.cancelHandler   = { [weak self] in self?.cancel() }
-                overlay.show()
-                self.overlays.append(overlay)
-            }
+        for screen in NSScreen.screens {
+            let image = await engine.captureRectToImage(screen.frame, on: screen)
+            var rect = NSRect(origin: .zero, size: screen.frame.size)
+            let frozenCG = image?.cgImage(forProposedRect: &rect, context: nil, hints: nil)
+            let overlay = SelectionOverlayWindow(screen: screen, mode: mode, frozenImage: frozenCG)
+            overlay.selectionHandler = { [weak self] rect in self?.finish(rect: rect, screen: screen) }
+            overlay.cancelHandler = { [weak self] in self?.cancel() }
+            overlay.show()
+            overlays.append(overlay)
         }
 
         focusFirstOverlay()
@@ -90,7 +81,7 @@ final class AreaSelectionWindow: NSObject {
         overlays.forEach { $0.orderOut(nil) }
         overlays.removeAll()
         // Restore background-only policy
-        NSApp.setActivationPolicy(.prohibited)
+        NSApp.restoreBackgroundOnlyActivationPolicyIfNeeded()
     }
 }
 

--- a/Sources/Shotnix/History/HistoryPanelController.swift
+++ b/Sources/Shotnix/History/HistoryPanelController.swift
@@ -221,7 +221,7 @@ final class HistoryPanelController: NSObject {
         panel = nil
         collectionView = nil
         emptyOverlay = nil
-        NSApp.setActivationPolicy(.prohibited)
+        NSApp.restoreBackgroundOnlyActivationPolicyIfNeeded(excluding: closedWindow)
     }
 
     @objc private func clearAll() {

--- a/Sources/Shotnix/Overlay/PinnedWindow.swift
+++ b/Sources/Shotnix/Overlay/PinnedWindow.swift
@@ -121,6 +121,7 @@ final class PinnedWindow: NSWindow {
     @objc private func closeTapped() {
         PinnedWindow.pinned.removeAll { $0 === self }
         orderOut(nil)
+        NSApp.restoreBackgroundOnlyActivationPolicyIfNeeded()
     }
 
     // MARK: – Right-click menu

--- a/Sources/Shotnix/Overlay/QuickAccessOverlay.swift
+++ b/Sources/Shotnix/Overlay/QuickAccessOverlay.swift
@@ -494,7 +494,7 @@ private final class QuickAccessWindow: NSWindow {
         // Restore background-only policy so app doesn't appear in Cmd-Tab
         // (skip when transitioning to another window like editor or pin)
         if QuickAccessWindow.openWindows.isEmpty && !skipPolicyReset {
-            NSApp.setActivationPolicy(.prohibited)
+            NSApp.restoreBackgroundOnlyActivationPolicyIfNeeded()
         }
     }
 

--- a/Sources/Shotnix/Utilities/NativeShortcutManager.swift
+++ b/Sources/Shotnix/Utilities/NativeShortcutManager.swift
@@ -99,7 +99,7 @@ enum NativeShortcutManager {
             showSuccessToast()
         }
 
-        NSApp.setActivationPolicy(.prohibited)
+        NSApp.restoreBackgroundOnlyActivationPolicyIfNeeded()
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

Cuts **v0.9.7-beta**, focused on window-lifecycle correctness and small annotation editor / arrow rendering polish.

## What changed

### Fixed
- **Cmd-Tab visibility** — closing one Shotnix window no longer drops the app from Cmd-Tab while other Shotnix windows remain open. Replaced hardcoded `NSApp.setActivationPolicy(.prohibited)` across the annotation editor, preferences, welcome, history, pinned-window, area-selection, quick-access overlay, and native-shortcut flows with a centralized helper.
- **Annotation editor layout** — toolbar reserves space for the macOS traffic-light buttons and enforces a minimum window width, so close/minimize/zoom no longer overlap toolbar controls.
- **Arrow rendering** — shafts stop short of the arrowhead by half the line width, removing the visible bulge at the tip on thick strokes.

### Changed
- **Multi-screen area capture** — per-screen freeze-frame loop simplified (sequential in place of `TaskGroup`); behavior unchanged.

### Internal
- New `NSApplication.restoreBackgroundOnlyActivationPolicyIfNeeded(excluding:)` helper in `Sources/Shotnix/App/ActivationPolicy.swift` is the single source of truth for menu-bar-app activation lifecycle.

### Release prep
- Bumped `CFBundleShortVersionString` to `0.9.7-beta`, `CFBundleVersion` to `8`.
- Updated `CHANGELOG.md`, README beta callout, and About-tab "What's New".

## Verification
- `swift build` — clean, no warnings.
- `bash build-app.sh` — produces a fresh `Shotnix.app` for release attachment.

## Files touched
13 files: 9 modified Swift sources, 1 new (`ActivationPolicy.swift`), `Info.plist`, `CHANGELOG.md`, `README.md`.