### PR TITLE
Add screenshot backdrops and release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.11.0] - 2026-05-09
+
+### Added
+- **Presentation backdrops** — annotation exports can now include per-image solid or gradient backgrounds with padding, rounded corners, and shadows.
+
+### Fixed
+- **Editor export parity** — the annotation editor preview now matches saved and copied output when a backdrop is enabled.
+- **Editor save flow** — save panels, copy feedback, and editor restoration are more reliable for the menu bar app lifecycle.
+- **Screenshot file promises** — history and overlay drag exports now write PNG data atomically and report encoding failures.
+
 ## [0.10.2-beta] - 2026-05-03
 
 ### Added

--- a/Info.plist
+++ b/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleDisplayName</key>
     <string>Shotnix</string>
     <key>CFBundleVersion</key>
-    <string>13</string>
+    <string>14</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.10.2-beta</string>
+    <string>0.11.0</string>
     <key>CFBundleExecutable</key>
     <string>Shotnix</string>
     <key>CFBundlePackageType</key>

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ---
 
 > [!NOTE]
-> **Shotnix is in beta (v0.10.2-beta).** It's fully functional but not yet notarized through Apple's Developer Program, so macOS will show a Gatekeeper warning on first launch. This is standard for open-source apps — Shotnix is safe and the source code is right here. Notarization is on the roadmap.
+> **Shotnix is in beta (v0.11.0).** It's fully functional but not yet notarized through Apple's Developer Program, so macOS will show a Gatekeeper warning on first launch. This is standard for open-source apps — Shotnix is safe and the source code is right here. Notarization is on the roadmap.
 >
 > To open: **Right-click → Open → Open** (macOS 13–14) or **System Settings → Privacy & Security → Open Anyway** (macOS 15+).
 
@@ -49,6 +49,7 @@ Visit **[shotnix.com](https://shotnix.com/)** for the latest download and projec
 - Arrows, rectangles, ellipses, lines, freehand drawing
 - Text annotations with customizable font and color
 - Highlighter for emphasizing content
+- Presentation backdrops for polished screenshot exports
 - Blur and pixelate for redacting sensitive info
 - Numbered markers for step-by-step guides
 - Crop to resize after capture

--- a/Sources/Shotnix/Annotation/AnnotationCanvas.swift
+++ b/Sources/Shotnix/Annotation/AnnotationCanvas.swift
@@ -34,6 +34,11 @@ final class AnnotationCanvas: NSView {
     // Crop overlay
     var cropRect: CGRect?
     var onCropChanged: ((CGRect?) -> Void)?
+    var backgroundOptions = ScreenshotBackgroundOptions.editorDefault
+    private var cachedPresentationImage: NSImage?
+    private var cachedPresentationSource: NSImage?
+    private var cachedPresentationOptions: ScreenshotBackgroundOptions?
+    private var cachedPresentationSize: NSSize = .zero
 
     // MARK: – Init
 
@@ -67,9 +72,9 @@ final class AnnotationCanvas: NSView {
     override func draw(_ dirtyRect: NSRect) {
         guard let ctx = NSGraphicsContext.current?.cgContext else { return }
 
-        // 1. Background image
+        // 1. Screenshot and optional presentation background
         if let img = backgroundImage {
-            img.draw(in: bounds)
+            drawBackgroundImage(img, ctx: ctx)
         }
 
         // 2. Blur and pixelate (CIFilter applied to background region)
@@ -101,15 +106,67 @@ final class AnnotationCanvas: NSView {
         }
     }
 
+    private func drawBackgroundImage(_ image: NSImage, ctx: CGContext) {
+        guard backgroundOptions.isEnabled else {
+            image.draw(in: bounds)
+            return
+        }
+
+        presentationImage(for: image).draw(in: bounds)
+    }
+
+    private func presentationImage(for image: NSImage) -> NSImage {
+        if let cachedPresentationImage,
+           cachedPresentationSource === image,
+           cachedPresentationOptions == backgroundOptions,
+           cachedPresentationSize == bounds.size {
+            return cachedPresentationImage
+        }
+
+        let composed = ScreenshotBackgroundComposer.composeIfNeeded(image, options: backgroundOptions)
+        cachedPresentationImage = composed
+        cachedPresentationSource = image
+        cachedPresentationOptions = backgroundOptions
+        cachedPresentationSize = bounds.size
+        return composed
+    }
+
+    private func backgroundImageRect(for image: NSImage) -> CGRect {
+        guard backgroundOptions.isEnabled else { return bounds }
+        let padding = clamped(backgroundOptions.padding, min: 0, max: 240)
+        return pixelAligned(
+            CGRect(x: padding, y: padding, width: image.size.width, height: image.size.height),
+            scale: max(window?.backingScaleFactor ?? 2, 1)
+        )
+    }
+
+    private func clamped(_ value: CGFloat, min: CGFloat, max: CGFloat) -> CGFloat {
+        Swift.min(Swift.max(value, min), max)
+    }
+
+    private func pixelAligned(_ rect: CGRect, scale: CGFloat) -> CGRect {
+        CGRect(
+            x: (rect.origin.x * scale).rounded() / scale,
+            y: (rect.origin.y * scale).rounded() / scale,
+            width: (rect.width * scale).rounded() / scale,
+            height: (rect.height * scale).rounded() / scale
+        )
+    }
+
     /// Convert a view rect (flipped, top-left origin) to CGImage coordinates (also top-left origin).
-    private func viewRectToCGImageRect(_ viewRect: CGRect, imageSize: CGSize) -> CGRect {
-        let scaleX = imageSize.width / bounds.width
-        let scaleY = imageSize.height / bounds.height
+    private func viewRectToCGImageRect(_ viewRect: CGRect, imageSize: CGSize) -> CGRect? {
+        guard let backgroundImage else { return nil }
+        let imageRect = backgroundImageRect(for: backgroundImage)
+        let clipped = viewRect.intersection(imageRect)
+        guard !clipped.isNull, !clipped.isEmpty else { return nil }
+
+        let scaleX = imageSize.width / imageRect.width
+        let scaleY = imageSize.height / imageRect.height
         return CGRect(
-            x: viewRect.origin.x * scaleX,
-            y: viewRect.origin.y * scaleY,
-            width: viewRect.width * scaleX,
-            height: viewRect.height * scaleY
+            x: (clipped.origin.x - imageRect.origin.x) * scaleX,
+            y: (clipped.origin.y - imageRect.origin.y) * scaleY,
+            width: clipped.width * scaleX,
+            height: clipped.height * scaleY
         )
     }
 
@@ -120,7 +177,7 @@ final class AnnotationCanvas: NSView {
         }
         guard let bg = backgroundImage, let cgImg = bg.cgImage(forProposedRect: nil, context: nil, hints: nil) else { return }
         let imgSize = CGSize(width: cgImg.width, height: cgImg.height)
-        let cropRect = viewRectToCGImageRect(blur.rect, imageSize: imgSize)
+        guard let cropRect = viewRectToCGImageRect(blur.rect, imageSize: imgSize) else { return }
         guard let croppedCG = cgImg.cropping(to: cropRect) else { return }
         let ci = CIImage(cgImage: croppedCG)
         guard let filter = CIFilter(name: "CIGaussianBlur") else { return }
@@ -143,7 +200,7 @@ final class AnnotationCanvas: NSView {
         }
         guard let bg = backgroundImage, let cgImg = bg.cgImage(forProposedRect: nil, context: nil, hints: nil) else { return }
         let imgSize = CGSize(width: cgImg.width, height: cgImg.height)
-        let cropRect = viewRectToCGImageRect(px.rect, imageSize: imgSize)
+        guard let cropRect = viewRectToCGImageRect(px.rect, imageSize: imgSize) else { return }
         guard let cropped = cgImg.cropping(to: cropRect) else { return }
         let ci = CIImage(cgImage: cropped)
         guard let filter = CIFilter(name: "CIPixellate") else { return }
@@ -719,6 +776,32 @@ final class AnnotationCanvas: NSView {
         for obj in selectedObjects where !(obj is TextAnnotation) && !(obj is NumberedStepAnnotation) {
             obj.lineWidth = lineWidth
         }
+        setNeedsDisplay(bounds)
+    }
+
+    func offsetContent(by delta: CGPoint) {
+        guard delta.x != 0 || delta.y != 0 else { return }
+
+        for obj in objects {
+            obj.move(by: delta)
+            if let blur = obj as? BlurAnnotation { blur.cachedRender = nil }
+            if let pixelate = obj as? PixelateAnnotation { pixelate.cachedRender = nil }
+        }
+
+        currentObject?.move(by: delta)
+
+        if var crop = cropRect {
+            crop.origin.x += delta.x
+            crop.origin.y += delta.y
+            cropRect = crop
+            onCropChanged?(crop)
+        }
+
+        if let activeTextField {
+            activeTextField.frame.origin.x += delta.x
+            activeTextField.frame.origin.y += delta.y
+        }
+
         setNeedsDisplay(bounds)
     }
 

--- a/Sources/Shotnix/Annotation/AnnotationWindowController.swift
+++ b/Sources/Shotnix/Annotation/AnnotationWindowController.swift
@@ -12,9 +12,24 @@ final class AnnotationWindowController: NSWindowController {
     private let historyItem: HistoryItem?
     private let historyManager: HistoryManager?
     private var image: NSImage
+    private var backgroundOptions = ScreenshotBackgroundOptions.editorDefault
 
     // Strong references so controllers aren't deallocated while their window is open
     private static var openControllers: [AnnotationWindowController] = []
+
+    static var hasOpenEditors: Bool {
+        !openControllers.isEmpty
+    }
+
+    static func bringOpenEditorsToFront() {
+        guard hasOpenEditors else { return }
+        NSApp.unhide(nil)
+        NSApp.setActivationPolicy(.accessory)
+        NSApp.activate(ignoringOtherApps: true)
+        for controller in openControllers {
+            controller.bringEditorToFront()
+        }
+    }
 
     static func open(image: NSImage, historyItem: HistoryItem? = nil, historyManager: HistoryManager? = nil) {
         let controller = AnnotationWindowController(image: image, historyItem: historyItem, historyManager: historyManager)
@@ -24,7 +39,7 @@ final class AnnotationWindowController: NSWindowController {
         controller.showWindow(nil)
         if let win = controller.window {
             win.alphaValue = 0
-            win.makeKeyAndOrderFront(nil)
+            controller.bringEditorToFront()
             NSAnimationContext.runAnimationGroup { ctx in
                 ctx.duration = 0.2
                 ctx.timingFunction = CAMediaTimingFunction(name: .easeOut)
@@ -60,6 +75,7 @@ final class AnnotationWindowController: NSWindowController {
         win.titleVisibility = .hidden
         win.titlebarAppearsTransparent = true
         win.isReleasedWhenClosed = false
+        win.level = .floating
         win.minSize = NSSize(width: Self.minimumEditorWidth, height: 240 + toolbarHeight)
         win.center()
 
@@ -107,6 +123,7 @@ final class AnnotationWindowController: NSWindowController {
         toolbar.onSave            = { [weak self] in self?.save() }
         toolbar.onCopy            = { [weak self] in self?.copyToClipboard() }
         toolbar.onApplyCrop       = { [weak self] in self?.applyCrop() }
+        toolbar.onBackgroundOptionsChanged = { [weak self] options in self?.applyBackgroundOptions(options) }
 
         // Sync tool changes from canvas keyboard shortcuts back to toolbar
         canvas.onToolChanged = { [weak self] tool in
@@ -140,23 +157,72 @@ final class AnnotationWindowController: NSWindowController {
 
     required init?(coder: NSCoder) { fatalError() }
 
+    private func bringEditorToFront() {
+        guard let window else { return }
+        NSApp.unhide(nil)
+        NSApp.setActivationPolicy(.accessory)
+        NSApp.activate(ignoringOtherApps: true)
+        showWindow(nil)
+        window.level = .floating
+        window.deminiaturize(nil)
+        window.makeKeyAndOrderFront(nil)
+        window.orderFrontRegardless()
+        window.makeFirstResponder(canvas)
+    }
+
     // MARK: – Actions
 
     private func save() {
         canvas.commitTextField()
-        let flat = canvas.flatten()
-        ImageExporter.saveWithPanel(image: flat, suggestedName: ImageExporter.timestampedName)
+        let flat = exportImage()
+        ImageExporter.saveWithPanel(image: flat, suggestedName: ImageExporter.timestampedName, presentingWindow: window) { [weak self] result in
+            self?.bringEditorToFront()
+            guard case .saved(let url) = result else { return }
+            ToastWindow.show(message: Self.savedScreenshotMessage(for: url), duration: 3.0)
+        }
     }
 
     private func copyToClipboard() {
         canvas.commitTextField()
-        let flat = canvas.flatten()
+        let flat = exportImage()
         ImageExporter.copyToClipboard(image: flat)
-        showBrieflyCopiedBanner()
+        ToastWindow.show(message: "Copied to clipboard")
+    }
+
+    private func exportImage() -> NSImage {
+        canvas.flatten()
+    }
+
+    private func applyBackgroundOptions(_ options: ScreenshotBackgroundOptions) {
+        canvas.commitTextField()
+
+        let oldPadding = previewPadding(for: backgroundOptions)
+        let newPadding = previewPadding(for: options)
+        backgroundOptions = options
+
+        canvas.backgroundOptions = options
+        canvas.backgroundImage = image
+        canvas.frame = NSRect(origin: .zero, size: previewSize(for: options))
+        canvas.offsetContent(by: CGPoint(x: newPadding - oldPadding, y: newPadding - oldPadding))
+        canvas.setNeedsDisplay(canvas.bounds)
+    }
+
+    private func previewSize(for options: ScreenshotBackgroundOptions) -> NSSize {
+        let padding = previewPadding(for: options)
+        return NSSize(width: image.size.width + padding * 2, height: image.size.height + padding * 2)
+    }
+
+    private func previewPadding(for options: ScreenshotBackgroundOptions) -> CGFloat {
+        guard options.isEnabled else { return 0 }
+        return min(max(options.padding, 0), 240)
     }
 
     private func applyCrop() {
         if let cropped = canvas.applyCrop() {
+            image = cropped
+            backgroundOptions = .editorDefault
+            toolbar.setBackgroundOptionsExternally(backgroundOptions)
+            canvas.backgroundOptions = backgroundOptions
             canvas.backgroundImage = cropped
             canvas.frame = NSRect(origin: .zero, size: cropped.size)
             canvas.objects.removeAll()
@@ -164,18 +230,11 @@ final class AnnotationWindowController: NSWindowController {
         }
     }
 
-    private func showBrieflyCopiedBanner() {
-        guard let win = window else { return }
-        let banner = NSTextField(labelWithString: "✓ Copied to clipboard")
-        banner.backgroundColor = NSColor.black.withAlphaComponent(0.75)
-        banner.textColor = .white
-        banner.isBezeled = false
-        banner.drawsBackground = true
-        banner.alignment = .center
-        guard let contentView = win.contentView else { return }
-        banner.frame = NSRect(x: contentView.bounds.midX - 100, y: 60, width: 200, height: 28)
-        contentView.addSubview(banner)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { banner.removeFromSuperview() }
+    private static func savedScreenshotMessage(for url: URL) -> String {
+        let folder = url.deletingLastPathComponent()
+        let folderName = FileManager.default.displayName(atPath: folder.path)
+        let destination = folderName.isEmpty ? folder.lastPathComponent : folderName
+        return "Saved to \(destination): \(url.lastPathComponent)"
     }
 }
 
@@ -223,7 +282,7 @@ final class CenteringClipView: NSClipView {
 @MainActor
 final class AnnotationToolbar: NSView {
 
-    static let requiredWidth: CGFloat = 870
+    static let requiredWidth: CGFloat = 982
 
     var onToolChanged: ((AnnotationTool) -> Void)?
     var onColorChanged: ((NSColor) -> Void)?
@@ -231,12 +290,16 @@ final class AnnotationToolbar: NSView {
     var onSave: (() -> Void)?
     var onCopy: (() -> Void)?
     var onApplyCrop: (() -> Void)?
+    var onBackgroundOptionsChanged: ((ScreenshotBackgroundOptions) -> Void)?
 
     private var toolButtons: [AnnotationTool: NSButton] = [:]
     private var selectedTool: AnnotationTool = .arrow
     private var colorButton: NSButton?
     private var colorPopover: NSPopover?
     private var cropApplyButton: NSButton?
+    private var backgroundButton: NSButton?
+    private var backgroundPopover: NSPopover?
+    private var backgroundOptions = ScreenshotBackgroundOptions.editorDefault
 
     override init(frame: NSRect) {
         super.init(frame: frame)
@@ -267,6 +330,7 @@ final class AnnotationToolbar: NSView {
 
         // Drawing tools group
         let drawingTools: [AnnotationTool] = [.select, .arrow, .rectangle, .filledRectangle, .ellipse, .line, .freehand]
+        addToolbarGroupBackground(x: x - 3, width: CGFloat(drawingTools.count) * 36 + 2)
         for tool in drawingTools {
             let btn = makeToolButton(tool: tool)
             btn.frame = NSRect(x: x, y: 8, width: 34, height: 34)
@@ -275,14 +339,11 @@ final class AnnotationToolbar: NSView {
             x += 36
         }
 
-        // Separator between groups
-        x += 4
-        let sep1 = NSBox(); sep1.boxType = .separator
-        sep1.frame = NSRect(x: x, y: 6, width: 1, height: 40)
-        addSubview(sep1); x += 8
+        x += 10
 
         // Annotation tools group
         let annotationTools: [AnnotationTool] = [.text, .numberedStep, .highlighter]
+        addToolbarGroupBackground(x: x - 3, width: CGFloat(annotationTools.count) * 36 + 2)
         for tool in annotationTools {
             let btn = makeToolButton(tool: tool)
             btn.frame = NSRect(x: x, y: 8, width: 34, height: 34)
@@ -291,14 +352,11 @@ final class AnnotationToolbar: NSView {
             x += 36
         }
 
-        // Separator
-        x += 4
-        let sep2 = NSBox(); sep2.boxType = .separator
-        sep2.frame = NSRect(x: x, y: 6, width: 1, height: 40)
-        addSubview(sep2); x += 8
+        x += 10
 
         // Effect tools group
         let effectTools: [AnnotationTool] = [.blur, .pixelate, .crop]
+        addToolbarGroupBackground(x: x - 3, width: CGFloat(effectTools.count) * 36 + 2)
         for tool in effectTools {
             let btn = makeToolButton(tool: tool)
             btn.frame = NSRect(x: x, y: 8, width: 34, height: 34)
@@ -307,14 +365,17 @@ final class AnnotationToolbar: NSView {
             x += 36
         }
 
-        // Separator
-        x += 4
-        let sep3 = NSBox(); sep3.boxType = .separator
-        sep3.frame = NSRect(x: x, y: 6, width: 1, height: 40)
-        addSubview(sep3); x += 8
+        x += 10
+
+        addToolbarGroupBackground(x: x - 6, width: 168)
 
         // Color button (circular, shows current color)
-        let colorBtn = NSButton(frame: NSRect(x: x, y: 10, width: 30, height: 30))
+        let colorBtn = NSButton(title: "", target: self, action: #selector(showColorPopover(_:)))
+        colorBtn.frame = NSRect(x: x, y: 10, width: 30, height: 30)
+        colorBtn.title = ""
+        colorBtn.alternateTitle = ""
+        colorBtn.attributedTitle = NSAttributedString(string: "")
+        colorBtn.imagePosition = .noImage
         colorBtn.wantsLayer = true
         colorBtn.layer?.cornerRadius = 15
         colorBtn.layer?.backgroundColor = NSColor.systemRed.cgColor
@@ -322,8 +383,6 @@ final class AnnotationToolbar: NSView {
         colorBtn.layer?.borderColor = NSColor.white.withAlphaComponent(0.3).cgColor
         colorBtn.isBordered = false
         colorBtn.bezelStyle = .regularSquare
-        colorBtn.target = self
-        colorBtn.action = #selector(showColorPopover(_:))
         colorBtn.toolTip = "Color"
         addSubview(colorBtn)
         colorButton = colorBtn
@@ -338,19 +397,27 @@ final class AnnotationToolbar: NSView {
         slider.frame = NSRect(x: x, y: 12, width: 80, height: 28)
         addSubview(slider); x += 88
 
-        // Separator
-        x += 4
-        let sep4 = NSBox(); sep4.boxType = .separator
-        sep4.frame = NSRect(x: x, y: 6, width: 1, height: 40)
-        addSubview(sep4); x += 8
+        x += 10
+
+        let backgroundBtn = NSButton(title: "Backdrop", target: self, action: #selector(backgroundTapped(_:)))
+        backgroundBtn.bezelStyle = .rounded
+        backgroundBtn.font = .systemFont(ofSize: 11, weight: .semibold)
+        backgroundBtn.image = NSImage(systemSymbolName: "sparkles", accessibilityDescription: nil)
+        backgroundBtn.imagePosition = .imageLeading
+        backgroundBtn.frame = NSRect(x: x, y: 10, width: 104, height: 30)
+        addSubview(backgroundBtn)
+        backgroundButton = backgroundBtn
+        x += 110
+
+        x += 2
 
         // Action buttons
         for (title, sel) in [("Copy", #selector(copyTapped)), ("Save", #selector(saveTapped))] {
             let btn = NSButton(title: title, target: self, action: sel)
             btn.bezelStyle = .rounded
-            btn.font = .systemFont(ofSize: 11)
-            btn.frame = NSRect(x: x, y: 11, width: 50, height: 28)
-            addSubview(btn); x += 54
+            btn.font = .systemFont(ofSize: 11, weight: title == "Save" ? .semibold : .regular)
+            btn.frame = NSRect(x: x, y: 10, width: 54, height: 30)
+            addSubview(btn); x += 58
         }
 
         // Crop apply button (only visible when a crop region is drawn)
@@ -363,6 +430,17 @@ final class AnnotationToolbar: NSView {
         cropApplyButton = cropBtn
 
         selectTool(.arrow)
+    }
+
+    private func addToolbarGroupBackground(x: CGFloat, width: CGFloat) {
+        let group = NSView(frame: NSRect(x: x, y: 6, width: width, height: 40))
+        group.wantsLayer = true
+        group.layer?.cornerRadius = 11
+        group.layer?.cornerCurve = .continuous
+        group.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.055).cgColor
+        group.layer?.borderWidth = 1
+        group.layer?.borderColor = NSColor.white.withAlphaComponent(0.055).cgColor
+        addSubview(group)
     }
 
     private func makeToolButton(tool: AnnotationTool) -> NSButton {
@@ -390,8 +468,9 @@ final class AnnotationToolbar: NSView {
         toolButtons[selectedTool]?.layer?.backgroundColor = nil
         selectedTool = tool
         toolButtons[tool]?.wantsLayer = true
-        toolButtons[tool]?.layer?.backgroundColor = NSColor.controlAccentColor.withAlphaComponent(0.2).cgColor
-        toolButtons[tool]?.layer?.cornerRadius = 6
+        toolButtons[tool]?.layer?.backgroundColor = NSColor.controlAccentColor.withAlphaComponent(0.28).cgColor
+        toolButtons[tool]?.layer?.cornerRadius = 8
+        toolButtons[tool]?.layer?.cornerCurve = .continuous
         if let newBtn = toolButtons[tool] as? AnnotationToolButton {
             newBtn.isSelectedTool = true
         }
@@ -403,6 +482,11 @@ final class AnnotationToolbar: NSView {
 
     func selectToolExternally(_ tool: AnnotationTool) {
         selectTool(tool)
+    }
+
+    func setBackgroundOptionsExternally(_ options: ScreenshotBackgroundOptions) {
+        backgroundOptions = options
+        backgroundButton?.contentTintColor = options.isEnabled ? .controlAccentColor : NSColor.labelColor.withAlphaComponent(0.86)
     }
 
     @objc private func showColorPopover(_ sender: NSButton) {
@@ -419,9 +503,205 @@ final class AnnotationToolbar: NSView {
     }
 
     @objc private func lineWidthChanged(_ sender: NSSlider) { onLineWidthChanged?(CGFloat(sender.doubleValue)) }
+    @objc private func backgroundTapped(_ sender: NSButton) {
+        if !backgroundOptions.isEnabled {
+            backgroundOptions.isEnabled = true
+            backgroundButton?.contentTintColor = .controlAccentColor
+            onBackgroundOptionsChanged?(backgroundOptions)
+        }
+
+        let controller = BackgroundPopoverController(options: backgroundOptions)
+        controller.onChange = { [weak self] options in
+            self?.backgroundOptions = options
+            self?.backgroundButton?.contentTintColor = options.isEnabled ? .controlAccentColor : NSColor.labelColor.withAlphaComponent(0.86)
+            self?.onBackgroundOptionsChanged?(options)
+        }
+        let popover = NSPopover()
+        popover.contentViewController = controller
+        popover.behavior = .transient
+        popover.show(relativeTo: sender.bounds, of: sender, preferredEdge: .minY)
+        backgroundPopover = popover
+    }
     @objc private func cropTapped()       { onApplyCrop?() }
     @objc private func copyTapped()       { onCopy?() }
     @objc private func saveTapped()       { onSave?() }
+}
+
+// MARK: - Per-image background popover
+
+@MainActor
+private final class BackgroundPopoverController: NSViewController {
+    var onChange: ((ScreenshotBackgroundOptions) -> Void)?
+
+    private var options: ScreenshotBackgroundOptions
+    private let enabledButton = NSButton(checkboxWithTitle: "Apply background to this image", target: nil, action: nil)
+    private let stylePopup = NSPopUpButton()
+    private let presetPopup = NSPopUpButton()
+    private let paddingSlider = NSSlider()
+    private let radiusSlider = NSSlider()
+    private let shadowSlider = NSSlider()
+    private let paddingValue = NSTextField(labelWithString: "")
+    private let radiusValue = NSTextField(labelWithString: "")
+    private let shadowValue = NSTextField(labelWithString: "")
+
+    private let solidPresets: [(String, String)] = [
+        ("Porcelain", "#f4eadb"),
+        ("Graphite", "#111827"),
+        ("Bone", "#eee7d6"),
+        ("Silver", "#d8dde7"),
+        ("Space Gray", "#2b3038"),
+        ("Moss", "#243528"),
+        ("Clay", "#7c3f2d")
+    ]
+    private let gradientPresets: [(name: String, start: String, end: String, accents: [String])] = [
+        ("Neo Pop", "#6a2cff", "#ffd36a", ["#ff7ac8", "#6af7ff", "#fff6b0"]),
+        ("Polar Dawn", "#07131e", "#6db8ff", ["#e9f6ff", "#173c63", "#a8d8ff"]),
+        ("Aurora Blue", "#050816", "#67d7ff", ["#7c3aed", "#38f8d4", "#d8f7ff"]),
+        ("Tahoe Ice", "#eaf4ff", "#1b6fe0", ["#ffffff", "#8dd7ff", "#3155d4"]),
+        ("Lavender Glass", "#f7f2ff", "#5b56f5", ["#ffb7e8", "#a3e8ff", "#ffffff"]),
+        ("Sunset Coral", "#fff0d8", "#ea4e79", ["#ffb86b", "#ffd1df", "#7c2d12"]),
+        ("Coastal Haze", "#071722", "#89e8f2", ["#0e5a78", "#e8fbff", "#2dd4bf"]),
+        ("Midnight Graphite", "#090b10", "#404c67", ["#99a4c7", "#1f2937", "#dbe4ff"]),
+        ("Ember Fog", "#160c0a", "#f4b06a", ["#6c2d1e", "#ffe7c8", "#ff6b3d"]),
+        ("Moss Glow", "#0e1b16", "#7fd3a0", ["#235543", "#eaf9f0", "#d4a95a"])
+    ]
+
+    init(options: ScreenshotBackgroundOptions) {
+        self.options = options
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func loadView() {
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: 300, height: 230))
+        var y: CGFloat = 194
+
+        enabledButton.frame = NSRect(x: 16, y: y, width: 260, height: 22)
+        enabledButton.target = self
+        enabledButton.action = #selector(enabledChanged)
+        container.addSubview(enabledButton)
+
+        y -= 38
+        addLabel("Style", x: 16, y: y + 4, to: container)
+        stylePopup.frame = NSRect(x: 106, y: y, width: 170, height: 26)
+        stylePopup.addItems(withTitles: ["Gradient", "Solid Color"])
+        stylePopup.target = self
+        stylePopup.action = #selector(styleChanged)
+        container.addSubview(stylePopup)
+
+        y -= 36
+        addLabel("Preset", x: 16, y: y + 4, to: container)
+        presetPopup.frame = NSRect(x: 106, y: y, width: 170, height: 26)
+        presetPopup.target = self
+        presetPopup.action = #selector(presetChanged)
+        container.addSubview(presetPopup)
+
+        y -= 42
+        addSliderRow("Padding", slider: paddingSlider, valueLabel: paddingValue, y: y, min: 0, max: 240, to: container)
+        y -= 38
+        addSliderRow("Radius", slider: radiusSlider, valueLabel: radiusValue, y: y, min: 0, max: 36, to: container)
+        y -= 38
+        addSliderRow("Shadow", slider: shadowSlider, valueLabel: shadowValue, y: y, min: 0, max: 1, to: container)
+
+        view = container
+        syncControls()
+    }
+
+    private func addLabel(_ text: String, x: CGFloat, y: CGFloat, to view: NSView) {
+        let label = NSTextField(labelWithString: text)
+        label.font = .systemFont(ofSize: 11)
+        label.frame = NSRect(x: x, y: y, width: 80, height: 16)
+        view.addSubview(label)
+    }
+
+    private func addSliderRow(_ title: String, slider: NSSlider, valueLabel: NSTextField, y: CGFloat, min: Double, max: Double, to view: NSView) {
+        addLabel(title, x: 16, y: y + 6, to: view)
+        slider.minValue = min
+        slider.maxValue = max
+        slider.target = self
+        slider.action = #selector(sliderChanged(_:))
+        slider.frame = NSRect(x: 106, y: y, width: 126, height: 26)
+        view.addSubview(slider)
+        valueLabel.font = .monospacedDigitSystemFont(ofSize: 11, weight: .regular)
+        valueLabel.alignment = .right
+        valueLabel.textColor = .secondaryLabelColor
+        valueLabel.frame = NSRect(x: 236, y: y + 5, width: 40, height: 16)
+        view.addSubview(valueLabel)
+    }
+
+    private func syncControls() {
+        enabledButton.state = options.isEnabled ? .on : .off
+        stylePopup.selectItem(at: options.style == .gradient ? 0 : 1)
+        paddingSlider.doubleValue = Double(options.padding)
+        radiusSlider.doubleValue = Double(options.cornerRadius)
+        shadowSlider.doubleValue = Double(options.shadow)
+        rebuildPresetPopup()
+        updateValueLabels()
+    }
+
+    private func rebuildPresetPopup() {
+        presetPopup.removeAllItems()
+        switch options.style {
+        case .solid:
+            presetPopup.addItems(withTitles: solidPresets.map(\.0))
+            if let index = solidPresets.firstIndex(where: { $0.0 == options.presetName }) {
+                presetPopup.selectItem(at: index)
+            }
+        case .gradient:
+            presetPopup.addItems(withTitles: gradientPresets.map(\.name))
+            if let index = gradientPresets.firstIndex(where: { $0.name == options.presetName }) {
+                presetPopup.selectItem(at: index)
+            }
+        }
+    }
+
+    private func updateValueLabels() {
+        paddingValue.stringValue = "\(Int(options.padding))"
+        radiusValue.stringValue = "\(Int(options.cornerRadius))"
+        shadowValue.stringValue = "\(Int(options.shadow * 100))%"
+    }
+
+    private func emitChange() {
+        updateValueLabels()
+        onChange?(options)
+    }
+
+    @objc private func enabledChanged() {
+        options.isEnabled = enabledButton.state == .on
+        emitChange()
+    }
+
+    @objc private func styleChanged() {
+        options.style = stylePopup.indexOfSelectedItem == 0 ? .gradient : .solid
+        rebuildPresetPopup()
+        presetChanged()
+    }
+
+    @objc private func presetChanged() {
+        let index = max(0, presetPopup.indexOfSelectedItem)
+        switch options.style {
+        case .solid:
+            let preset = solidPresets[min(index, solidPresets.count - 1)]
+            options.presetName = preset.0
+            options.colorHex = preset.1
+            options.accentHexes = []
+        case .gradient:
+            let preset = gradientPresets[min(index, gradientPresets.count - 1)]
+            options.presetName = preset.name
+            options.gradientStartHex = preset.start
+            options.gradientEndHex = preset.end
+            options.accentHexes = preset.accents
+        }
+        emitChange()
+    }
+
+    @objc private func sliderChanged(_ sender: NSSlider) {
+        if sender === paddingSlider { options.padding = CGFloat(sender.doubleValue.rounded()) }
+        if sender === radiusSlider { options.cornerRadius = CGFloat(sender.doubleValue.rounded()) }
+        if sender === shadowSlider { options.shadow = CGFloat(sender.doubleValue) }
+        emitChange()
+    }
 }
 
 // MARK: – Annotation tool button with hover + press feedback
@@ -463,6 +743,7 @@ private final class AnnotationToolButton: NSButton {
     }
 
     override func mouseDown(with event: NSEvent) {
+        wantsLayer = true
         let scale = CATransform3DMakeScale(0.92, 0.92, 1)
         layer?.transform = scale
         super.mouseDown(with: event)

--- a/Sources/Shotnix/App/AppDelegate.swift
+++ b/Sources/Shotnix/App/AppDelegate.swift
@@ -61,6 +61,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         menu.addItem(title: "Capture Text (OCR)",   key: "o",  action: #selector(captureText), icon: "text.viewfinder")
         menu.addItem(title: "Scan QR Code",         key: "",  action: #selector(scanQRCode), icon: "qrcode.viewfinder")
         menu.addItem(title: "Open History",         key: "",  action: #selector(openHistory), icon: "clock.arrow.circlepath")
+        menu.addItem(title: "Show Editor",          key: "",  action: #selector(showEditor), icon: "pencil.and.outline")
         menu.addItem(title: "Annotate Last Screenshot", key: "", action: #selector(annotateLastScreenshot), icon: "pencil.tip.crop.circle")
         menu.addItem(.separator())
 
@@ -91,6 +92,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
     @objc func stopRecording()       { captureEngine.stopRecording() }
     @objc func captureText()         { Task { await captureEngine.startOCRCapture() } }
     @objc func scanQRCode()          { Task { await captureEngine.startQRCodeCapture() } }
+    @objc func showEditor()          { AnnotationWindowController.bringOpenEditorsToFront() }
     @objc func annotateLastScreenshot() {
         guard let last = historyManager.items.first else { return }
         AnnotationWindowController.open(image: last.fullImage, historyItem: last, historyManager: historyManager)
@@ -108,6 +110,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
             || menuItem.action == #selector(recordWindow)
             || menuItem.action == #selector(recordFullscreen) {
             return captureEngine?.recordingActionsEnabled ?? false
+        }
+        if menuItem.action == #selector(showEditor) {
+            return AnnotationWindowController.hasOpenEditors
         }
         return true
     }

--- a/Sources/Shotnix/App/PreferencesWindowController.swift
+++ b/Sources/Shotnix/App/PreferencesWindowController.swift
@@ -232,7 +232,7 @@ struct ScreenshotsSettingsView: View {
             } header: {
                 Text("Export Format")
             }
-            
+
             Section {
                 HStack {
                     Text(displayLocation)
@@ -265,7 +265,7 @@ struct ScreenshotsSettingsView: View {
             }
         }
         .formStyle(.grouped)
-        .frame(width: 500, height: 350)
+        .frame(width: 500, height: 430)
     }
 }
 
@@ -352,7 +352,7 @@ struct RecordingSettingsView: View {
 }
 
 struct AboutSettingsView: View {
-    let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.10.2-beta"
+    let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.11.0"
     
     var body: some View {
         VStack(alignment: .center, spacing: 16) {
@@ -377,6 +377,11 @@ struct AboutSettingsView: View {
                 
                 ScrollView {
                     Text("""
+                    Version 0.11.0
+                    • Per-image Backdrop controls for presentation-ready screenshot exports
+                    • Annotation editor now previews styled backgrounds exactly as saved
+                    • Save panels, editor restore, and local signing are more reliable
+
                     Version 0.10.2-beta
                     • Record Window now shows premium preview cards with app icons and target details
                     • Desktop/backstop windows are filtered out of the picker

--- a/Sources/Shotnix/History/HistoryPanelController.swift
+++ b/Sources/Shotnix/History/HistoryPanelController.swift
@@ -289,8 +289,45 @@ extension HistoryPanelController: NSCollectionViewDelegate {
     ) -> (any NSPasteboardWriting)? {
         guard !sections.isEmpty else { return nil }
         let item = sections[indexPath.section].items[indexPath.item]
-        let url = URL(fileURLWithPath: item.imagePath) as NSURL
-        return url
+        return NSFilePromiseProvider(fileType: "public.png", delegate: HistoryImageFilePromiseDelegate(image: item.fullImage))
+    }
+}
+
+private final class HistoryImageFilePromiseDelegate: NSObject, NSFilePromiseProviderDelegate, @unchecked Sendable {
+
+    private static let queue: OperationQueue = {
+        let queue = OperationQueue()
+        queue.name = "Shotnix.HistoryFilePromise"
+        queue.maxConcurrentOperationCount = 1
+        queue.qualityOfService = .userInitiated
+        return queue
+    }()
+
+    private let image: NSImage
+
+    init(image: NSImage) {
+        self.image = image
+    }
+
+    func filePromiseProvider(_ filePromiseProvider: NSFilePromiseProvider, fileNameForType fileType: String) -> String {
+        "\(ImageExporter.timestampedName).png"
+    }
+
+    func filePromiseProvider(_ filePromiseProvider: NSFilePromiseProvider, writePromiseTo url: URL, completionHandler handler: @escaping (Error?) -> Void) {
+        do {
+            guard let png = ImageExporter.pngData(from: image) else {
+                handler(ImageExporter.ExportError.pngEncodingFailed)
+                return
+            }
+            try png.write(to: url, options: .atomic)
+            handler(nil)
+        } catch {
+            handler(error)
+        }
+    }
+
+    func operationQueue(for filePromiseProvider: NSFilePromiseProvider) -> OperationQueue {
+        Self.queue
     }
 }
 

--- a/Sources/Shotnix/Overlay/PinnedWindow.swift
+++ b/Sources/Shotnix/Overlay/PinnedWindow.swift
@@ -153,7 +153,11 @@ final class PinnedWindow: NSWindow {
 
     @objc private func savePinnedImage() {
         guard let image = imageView.image else { return }
-        ImageExporter.saveWithPanel(image: image, suggestedName: ImageExporter.timestampedName)
+        ImageExporter.saveWithPanel(image: image, suggestedName: ImageExporter.timestampedName, presentingWindow: self) { result in
+            if result.didSave {
+                ToastWindow.show(message: "✓ Saved screenshot")
+            }
+        }
     }
 
     @objc private func editPinnedImage() {

--- a/Sources/Shotnix/Overlay/QuickAccessOverlay.swift
+++ b/Sources/Shotnix/Overlay/QuickAccessOverlay.swift
@@ -506,8 +506,8 @@ private final class QuickAccessWindow: NSWindow {
     }
 
     @objc private func saveAction() {
-        ImageExporter.saveWithPanel(image: image, suggestedName: ImageExporter.timestampedName) { [weak self] success in
-            if success {
+        ImageExporter.saveWithPanel(image: image, suggestedName: ImageExporter.timestampedName) { [weak self] result in
+            if result.didSave {
                 self?.showConfirmation(icon: "arrow.down.circle") { [weak self] in self?.animatedClose() }
             }
         }
@@ -656,9 +656,11 @@ private final class ImageFilePromiseDelegate: NSObject, NSFilePromiseProviderDel
 
     func filePromiseProvider(_ filePromiseProvider: NSFilePromiseProvider, writePromiseTo url: URL, completionHandler handler: @escaping (Error?) -> Void) {
         do {
-            if let png = ImageExporter.pngData(from: image) {
-                try png.write(to: url)
+            guard let png = ImageExporter.pngData(from: image) else {
+                handler(ImageExporter.ExportError.pngEncodingFailed)
+                return
             }
+            try png.write(to: url, options: .atomic)
             handler(nil)
         } catch {
             handler(error)

--- a/Sources/Shotnix/Utilities/ImageExporter.swift
+++ b/Sources/Shotnix/Utilities/ImageExporter.swift
@@ -4,7 +4,30 @@ import ImageIO
 
 enum ImageExporter {
 
+    enum ExportError: LocalizedError {
+        case pngEncodingFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .pngEncodingFailed:
+                "Could not encode screenshot as PNG."
+            }
+        }
+    }
+
+    enum SavePanelResult {
+        case saved(URL)
+        case cancelled
+        case failed(URL?)
+
+        var didSave: Bool {
+            if case .saved = self { return true }
+            return false
+        }
+    }
+
     private static let webpUTI = "org.webmproject.webp" as CFString
+    private static var activeSavePanels: [NSSavePanel] = []
 
     // MARK: – Clipboard
 
@@ -31,18 +54,72 @@ enum ImageExporter {
 
     // MARK: – Save with panel
 
-    static func saveWithPanel(image: NSImage, suggestedName: String, completion: ((Bool) -> Void)? = nil) {
+    @MainActor
+    static func saveWithPanel(image: NSImage, suggestedName: String, presentingWindow: NSWindow? = nil, completion: ((SavePanelResult) -> Void)? = nil) {
+        NSApp.unhide(nil)
+        NSApp.setActivationPolicy(.accessory)
+        NSApp.activate(ignoringOtherApps: true)
+        presentingWindow?.deminiaturize(nil)
+        presentingWindow?.makeKeyAndOrderFront(nil)
+        presentingWindow?.orderFrontRegardless()
+
         let panel = NSSavePanel()
         let preferredExt = Settings.screenshotFormat
         panel.nameFieldStringValue = "\(suggestedName).\(preferredExt)"
         panel.allowedContentTypes = [.png, .jpeg, UTType("org.webmproject.webp") ?? .data]
         panel.canCreateDirectories = true
-        panel.begin { response in
-            if response == .OK, let url = panel.url {
-                completion?(save(image: image, to: url) != nil)
-            } else {
-                completion?(false)
+        panel.canSelectHiddenExtension = true
+        panel.isExtensionHidden = false
+        panel.directoryURL = FileManager.default.urls(for: .desktopDirectory, in: .userDomainMask).first
+
+        activeSavePanels.append(panel)
+
+        let handler: (NSApplication.ModalResponse) -> Void = { response in
+            activeSavePanels.removeAll { $0 === panel }
+
+            guard response == .OK else {
+                completion?(.cancelled)
+                return
             }
+
+            guard let url = panel.url else {
+                completion?(.failed(nil))
+                showSaveFailedAlert(for: nil, presentingWindow: presentingWindow)
+                return
+            }
+
+            guard let savedURL = save(image: image, to: url) else {
+                completion?(.failed(url))
+                showSaveFailedAlert(for: url, presentingWindow: presentingWindow)
+                return
+            }
+
+            completion?(.saved(savedURL))
+        }
+
+        if let presentingWindow {
+            panel.beginSheetModal(for: presentingWindow, completionHandler: handler)
+        } else {
+            panel.begin(completionHandler: handler)
+        }
+    }
+
+    @MainActor
+    private static func showSaveFailedAlert(for url: URL?, presentingWindow: NSWindow?) {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Could Not Save Screenshot"
+        if let url {
+            alert.informativeText = "Shotnix could not write the file to:\n\(url.path)"
+        } else {
+            alert.informativeText = "The save panel did not return a destination. Please try saving again."
+        }
+        alert.addButton(withTitle: "OK")
+
+        if let presentingWindow, presentingWindow.isVisible {
+            alert.beginSheetModal(for: presentingWindow)
+        } else {
+            alert.runModal()
         }
     }
 

--- a/Sources/Shotnix/Utilities/ScreenshotBackgroundComposer.swift
+++ b/Sources/Shotnix/Utilities/ScreenshotBackgroundComposer.swift
@@ -1,0 +1,238 @@
+import AppKit
+
+struct ScreenshotBackgroundOptions: Equatable {
+    enum Style: String {
+        case solid
+        case gradient
+    }
+
+    var isEnabled: Bool
+    var style: Style
+    var presetName: String
+    var colorHex: String
+    var gradientStartHex: String
+    var gradientEndHex: String
+    var accentHexes: [String]
+    var padding: CGFloat
+    var cornerRadius: CGFloat
+    var shadow: CGFloat
+
+    static let editorDefault = ScreenshotBackgroundOptions(
+        isEnabled: false,
+        style: .gradient,
+        presetName: "Neo Pop",
+        colorHex: "#f4eadb",
+        gradientStartHex: "#6a2cff",
+        gradientEndHex: "#ffd36a",
+        accentHexes: ["#ff7ac8", "#6af7ff", "#fff6b0"],
+        padding: 72,
+        cornerRadius: 18,
+        shadow: 0.32
+    )
+}
+
+enum ScreenshotBackgroundComposer {
+
+    static func composeIfNeeded(_ image: NSImage, options: ScreenshotBackgroundOptions) -> NSImage {
+        guard options.isEnabled else { return image }
+        guard let source = image.bestCGImage else { return image }
+
+        let sourcePointSize = image.size
+        guard sourcePointSize.width > 0, sourcePointSize.height > 0 else { return image }
+
+        let scale = max(
+            CGFloat(source.width) / sourcePointSize.width,
+            CGFloat(source.height) / sourcePointSize.height,
+            1
+        )
+        let padding = clamped(options.padding, min: 0, max: 240)
+        let outputPointSize = NSSize(
+            width: sourcePointSize.width + padding * 2,
+            height: sourcePointSize.height + padding * 2
+        )
+        let pixelWidth = max(1, Int(ceil(outputPointSize.width * scale)))
+        let pixelHeight = max(1, Int(ceil(outputPointSize.height * scale)))
+
+        let colorSpace = source.colorSpace ?? CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+        guard let context = CGContext(
+            data: nil,
+            width: pixelWidth,
+            height: pixelHeight,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return image }
+
+        context.interpolationQuality = .high
+        context.scaleBy(x: scale, y: scale)
+
+        let outputRect = CGRect(origin: .zero, size: outputPointSize)
+        drawBackground(in: context, rect: outputRect, options: options)
+
+        let imageRect = pixelAligned(CGRect(origin: CGPoint(x: padding, y: padding), size: sourcePointSize), scale: scale)
+        let radius = cornerRadius(for: imageRect, options: options)
+        drawShadow(in: context, container: outputRect, rect: imageRect, radius: radius, intensity: clamped(options.shadow, min: 0, max: 1))
+
+        context.saveGState()
+        context.setAllowsAntialiasing(true)
+        context.setShouldAntialias(true)
+        context.addPath(roundedPath(for: imageRect, radius: radius))
+        context.clip()
+        context.draw(source, in: imageRect)
+        context.restoreGState()
+        drawEdgeStroke(in: context, rect: imageRect, radius: radius, scale: scale)
+
+        guard let composed = context.makeImage() else { return image }
+        let rep = NSBitmapImageRep(cgImage: composed)
+        rep.size = outputPointSize
+        let output = NSImage(size: outputPointSize)
+        output.addRepresentation(rep)
+        return output
+    }
+
+    private static func drawBackground(in context: CGContext, rect: CGRect, options: ScreenshotBackgroundOptions) {
+        if options.style == .gradient {
+            let start = color(from: options.gradientStartHex)
+            let end = color(from: options.gradientEndHex)
+            let colors = [start.cgColor, end.cgColor] as CFArray
+            let colorSpace = start.cgColor.colorSpace ?? CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+            if let gradient = CGGradient(colorsSpace: colorSpace, colors: colors, locations: [0, 1]) {
+                context.drawLinearGradient(
+                    gradient,
+                    start: CGPoint(x: rect.minX, y: rect.minY),
+                    end: CGPoint(x: rect.maxX, y: rect.maxY),
+                    options: []
+                )
+                drawProceduralBlooms(in: context, rect: rect, options: options, start: start, end: end)
+                drawVignette(in: context, rect: rect)
+                return
+            }
+        }
+
+        context.setFillColor(color(from: options.colorHex).cgColor)
+        context.fill(rect)
+        drawVignette(in: context, rect: rect)
+    }
+
+    private static func drawProceduralBlooms(in context: CGContext, rect: CGRect, options: ScreenshotBackgroundOptions, start: NSColor, end: NSColor) {
+        let fallback = [end, start]
+        let accents = options.accentHexes.isEmpty ? fallback : options.accentHexes.map(color(from:))
+        let centers = [
+            CGPoint(x: rect.minX + rect.width * 0.18, y: rect.minY + rect.height * 0.78),
+            CGPoint(x: rect.minX + rect.width * 0.84, y: rect.minY + rect.height * 0.22),
+            CGPoint(x: rect.minX + rect.width * 0.58, y: rect.minY + rect.height * 0.92),
+            CGPoint(x: rect.minX + rect.width * 0.28, y: rect.minY + rect.height * 0.18)
+        ]
+
+        for (index, color) in accents.prefix(4).enumerated() {
+            let radius = max(rect.width, rect.height) * (index == 0 ? 0.68 : 0.48)
+            drawGradientGlow(in: context, rect: rect, color: color, center: centers[index], radius: radius, alpha: index == 0 ? 0.34 : 0.24)
+        }
+    }
+
+    private static func drawGradientGlow(in context: CGContext, rect: CGRect, color: NSColor, center: CGPoint, radius: CGFloat, alpha: CGFloat) {
+        let colors = [
+            color.withAlphaComponent(alpha).cgColor,
+            color.withAlphaComponent(0).cgColor
+        ] as CFArray
+        let colorSpace = color.cgColor.colorSpace ?? CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+        guard let gradient = CGGradient(colorsSpace: colorSpace, colors: colors, locations: [0, 1]) else { return }
+        context.drawRadialGradient(
+            gradient,
+            startCenter: center,
+            startRadius: 0,
+            endCenter: center,
+            endRadius: radius,
+            options: .drawsAfterEndLocation
+        )
+    }
+
+    private static func drawVignette(in context: CGContext, rect: CGRect) {
+        let colors = [
+            NSColor.black.withAlphaComponent(0).cgColor,
+            NSColor.black.withAlphaComponent(0.12).cgColor
+        ] as CFArray
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+        guard let gradient = CGGradient(colorsSpace: colorSpace, colors: colors, locations: [0.52, 1]) else { return }
+        let center = CGPoint(x: rect.midX, y: rect.midY)
+        context.drawRadialGradient(
+            gradient,
+            startCenter: center,
+            startRadius: min(rect.width, rect.height) * 0.14,
+            endCenter: center,
+            endRadius: max(rect.width, rect.height) * 0.72,
+            options: .drawsAfterEndLocation
+        )
+    }
+
+    private static func drawShadow(in context: CGContext, container: CGRect, rect: CGRect, radius: CGFloat, intensity: CGFloat) {
+        guard intensity > 0 else { return }
+
+        let path = roundedPath(for: rect, radius: radius)
+        let outerRect = container.insetBy(dx: -120, dy: -120)
+        let shadowClip = CGMutablePath()
+        shadowClip.addRect(outerRect)
+        shadowClip.addPath(path)
+
+        context.saveGState()
+        context.addPath(shadowClip)
+        context.clip(using: .evenOdd)
+        context.setShadow(
+            offset: CGSize(width: 0, height: -18 * intensity),
+            blur: 42 * intensity,
+            color: NSColor.black.withAlphaComponent(0.45 * intensity).cgColor
+        )
+        context.setFillColor(NSColor.black.withAlphaComponent(0.35).cgColor)
+        context.addPath(path)
+        context.fillPath()
+        context.restoreGState()
+    }
+
+    private static func drawEdgeStroke(in context: CGContext, rect: CGRect, radius: CGFloat, scale: CGFloat) {
+        let lineWidth = CGFloat(1) / max(scale, 1)
+        let strokeRect = rect.insetBy(dx: lineWidth / 2, dy: lineWidth / 2)
+        let strokeRadius = max(0, radius - lineWidth / 2)
+
+        context.saveGState()
+        context.setAllowsAntialiasing(true)
+        context.setShouldAntialias(true)
+        context.setLineWidth(lineWidth)
+        context.setStrokeColor(NSColor.white.withAlphaComponent(0.18).cgColor)
+        context.addPath(roundedPath(for: strokeRect, radius: strokeRadius))
+        context.strokePath()
+        context.restoreGState()
+    }
+
+    private static func color(from hex: String) -> NSColor {
+        let trimmed = hex.trimmingCharacters(in: CharacterSet(charactersIn: "# "))
+        guard trimmed.count == 6, let value = Int(trimmed, radix: 16) else {
+            return NSColor(calibratedRed: 0.07, green: 0.09, blue: 0.14, alpha: 1)
+        }
+        let red = CGFloat((value >> 16) & 0xff) / 255
+        let green = CGFloat((value >> 8) & 0xff) / 255
+        let blue = CGFloat(value & 0xff) / 255
+        return NSColor(calibratedRed: red, green: green, blue: blue, alpha: 1)
+    }
+
+    private static func clamped(_ value: CGFloat, min: CGFloat, max: CGFloat) -> CGFloat {
+        Swift.min(Swift.max(value, min), max)
+    }
+
+    private static func cornerRadius(for rect: CGRect, options: ScreenshotBackgroundOptions) -> CGFloat {
+        min(clamped(options.cornerRadius, min: 0, max: 36), min(rect.width, rect.height) / 2)
+    }
+
+    private static func roundedPath(for rect: CGRect, radius: CGFloat) -> CGPath {
+        CGPath(roundedRect: rect, cornerWidth: radius, cornerHeight: radius, transform: nil)
+    }
+
+    private static func pixelAligned(_ rect: CGRect, scale: CGFloat) -> CGRect {
+        CGRect(
+            x: (rect.origin.x * scale).rounded() / scale,
+            y: (rect.origin.y * scale).rounded() / scale,
+            width: (rect.width * scale).rounded() / scale,
+            height: (rect.height * scale).rounded() / scale
+        )
+    }
+}

--- a/build-app.sh
+++ b/build-app.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 APP_NAME="Shotnix"
 APP_BUNDLE="$SCRIPT_DIR/$APP_NAME.app"
 ENTITLEMENTS="$SCRIPT_DIR/Shotnix.entitlements"
+SIGN_IDENTITY="${SHOTNIX_CODESIGN_IDENTITY:-Shotnix Local Dev}"
 
 echo "▶ Building $APP_NAME (release)…"
 cd "$SCRIPT_DIR"
@@ -33,8 +34,8 @@ if [ -f "$SCRIPT_DIR/PrivacyInfo.xcprivacy" ]; then
     cp "$SCRIPT_DIR/PrivacyInfo.xcprivacy" "$APP_BUNDLE/Contents/Resources/PrivacyInfo.xcprivacy"
 fi
 
-echo "▶ Ad-hoc signing…"
-codesign --force --deep --sign - \
+echo "Signing with $SIGN_IDENTITY..."
+codesign --force --deep --sign "$SIGN_IDENTITY" \
     --options runtime \
     --entitlements "$ENTITLEMENTS" \
     "$APP_BUNDLE"


### PR DESCRIPTION
## Summary
- Add procedural per-image backdrop rendering for annotated screenshots, with solid/gradient presets, padding, radius, and shadow controls.
- Make editor preview, copy, and save output share the same composed export path.
- Harden save panels, file promises, local signing, and release metadata for v0.11.0.

## Verification
- LSP diagnostics: 0 diagnostics across Sources/Shotnix
- swift build
- swift test (no test target configured)
- bash -n build-app.sh
- bash build-app.sh
- codesign --verify --deep --strict --verbose=2 /Applications/Shotnix.app
- git diff --check