### PR TITLE
Add custom image backdrops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.12.0-beta] - 2026-05-10
+
+### Added
+- **Image backdrops** — annotation exports can now use generated image-style backgrounds or a custom user-selected image.
+
+### Changed
+- **Editor shell polish** — the annotation editor has a refined stage, floating toolbar dock, compact background popovers, and cleaner toolbar spacing.
+
+### Fixed
+- **Editor controls** — numbered markers, color swatches, Background controls, and popover style switching now render cleanly without clipped labels or stale layout.
+
 ## [0.11.0-beta] - 2026-05-09
 
 ### Added

--- a/Info.plist
+++ b/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleDisplayName</key>
     <string>Shotnix</string>
     <key>CFBundleVersion</key>
-    <string>14</string>
+    <string>15</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.11.0-beta</string>
+    <string>0.12.0-beta</string>
     <key>CFBundleExecutable</key>
     <string>Shotnix</string>
     <key>CFBundlePackageType</key>

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ---
 
 > [!NOTE]
-> **Shotnix is in beta (v0.11.0-beta).** It's fully functional but not yet notarized through Apple's Developer Program, so macOS will show a Gatekeeper warning on first launch. This is standard for open-source apps — Shotnix is safe and the source code is right here. Notarization is on the roadmap.
+> **Shotnix is in beta (v0.12.0-beta).** It's fully functional but not yet notarized through Apple's Developer Program, so macOS will show a Gatekeeper warning on first launch. This is standard for open-source apps — Shotnix is safe and the source code is right here. Notarization is on the roadmap.
 >
 > To open: **Right-click → Open → Open** (macOS 13–14) or **System Settings → Privacy & Security → Open Anyway** (macOS 15+).
 
@@ -49,7 +49,7 @@ Visit **[shotnix.com](https://shotnix.com/)** for the latest download and projec
 - Arrows, rectangles, ellipses, lines, freehand drawing
 - Text annotations with customizable font and color
 - Highlighter for emphasizing content
-- Presentation backdrops for polished screenshot exports
+- Presentation backdrops for polished screenshot exports, including image presets and custom images
 - Blur and pixelate for redacting sensitive info
 - Numbered markers for step-by-step guides
 - Crop to resize after capture

--- a/Sources/Shotnix/Annotation/AnnotationObject.swift
+++ b/Sources/Shotnix/Annotation/AnnotationObject.swift
@@ -561,9 +561,12 @@ final class NumberedStepAnnotation: AnnotationObject {
 
     private var textLayout: (font: NSFont, attrs: [NSAttributedString.Key: Any], size: CGSize) {
         let font = NSFont.boldSystemFont(ofSize: diameter * 0.55)
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.alignment = .center
         let attrs: [NSAttributedString.Key: Any] = [
             .font: font,
-            .foregroundColor: NSColor.white
+            .foregroundColor: NSColor.white,
+            .paragraphStyle: paragraphStyle
         ]
         let size = ("\(number)" as NSString).size(withAttributes: attrs)
         return (font, attrs, size)
@@ -620,17 +623,22 @@ final class NumberedStepAnnotation: AnnotationObject {
         ctx.setLineWidth(1)
         ctx.strokeEllipse(in: circleRect)
 
-        // Number text (centered, white, bold) — font + size cached as lazy property
         let layout = textLayout
-        let textOrigin = CGPoint(
-            x: circleRect.midX - layout.size.width / 2,
-            y: circleRect.midY - layout.size.height / 2
+        let textRect = CGRect(
+            x: circleRect.minX,
+            y: circleRect.midY - layout.size.height / 2 - 1,
+            width: circleRect.width,
+            height: layout.size.height + 2
         )
 
         NSGraphicsContext.saveGraphicsState()
         let nsCtx = NSGraphicsContext(cgContext: ctx, flipped: true)
         NSGraphicsContext.current = nsCtx
-        ("\(number)" as NSString).draw(at: textOrigin, withAttributes: layout.attrs)
+        ("\(number)" as NSString).draw(
+            with: textRect,
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            attributes: layout.attrs
+        )
         NSGraphicsContext.restoreGraphicsState()
 
         ctx.restoreGState()

--- a/Sources/Shotnix/Annotation/AnnotationWindowController.swift
+++ b/Sources/Shotnix/Annotation/AnnotationWindowController.swift
@@ -347,7 +347,7 @@ private final class PremiumEditorStageView: NSView {
 @MainActor
 final class AnnotationToolbar: NSView {
 
-    static let requiredWidth: CGFloat = 982
+    static let requiredWidth: CGFloat = 930
 
     var onToolChanged: ((AnnotationTool) -> Void)?
     var onColorChanged: ((NSColor) -> Void)?
@@ -475,15 +475,15 @@ final class AnnotationToolbar: NSView {
 
         x += 10
 
-        let backgroundBtn = PremiumToolbarActionButton(title: "Backdrop", target: self, action: #selector(backgroundTapped(_:)))
+        let backgroundBtn = PremiumToolbarActionButton(title: "Background", target: self, action: #selector(backgroundTapped(_:)))
         backgroundBtn.bezelStyle = .regularSquare
         backgroundBtn.font = .systemFont(ofSize: 11, weight: .semibold)
-        backgroundBtn.image = NSImage(systemSymbolName: "sparkles", accessibilityDescription: nil)
-        backgroundBtn.imagePosition = .imageLeading
-        backgroundBtn.frame = NSRect(x: x, y: 10, width: 104, height: 30)
+        backgroundBtn.imagePosition = .noImage
+        backgroundBtn.toolTip = "Background"
+        backgroundBtn.frame = NSRect(x: x, y: 10, width: 110, height: 30)
         addSubview(backgroundBtn)
         backgroundButton = backgroundBtn
-        x += 110
+        x += 116
 
         x += 2
 
@@ -595,6 +595,7 @@ final class AnnotationToolbar: NSView {
         let popover = NSPopover()
         popover.contentViewController = controller
         popover.behavior = .transient
+        controller.popover = popover
         popover.show(relativeTo: sender.bounds, of: sender, preferredEdge: .minY)
         backgroundPopover = popover
     }
@@ -608,6 +609,7 @@ final class AnnotationToolbar: NSView {
 @MainActor
 private final class BackgroundPopoverController: NSViewController {
     var onChange: ((ScreenshotBackgroundOptions) -> Void)?
+    weak var popover: NSPopover?
 
     private var options: ScreenshotBackgroundOptions
     private let enabledButton = NSButton(checkboxWithTitle: "Apply background to this image", target: nil, action: nil)
@@ -620,8 +622,15 @@ private final class BackgroundPopoverController: NSViewController {
     private let paddingValue = NSTextField(labelWithString: "")
     private let radiusValue = NSTextField(labelWithString: "")
     private let shadowValue = NSTextField(labelWithString: "")
+    private var styleLabel: NSTextField?
     private var presetLabel: NSTextField?
+    private var paddingLabel: NSTextField?
+    private var radiusLabel: NSTextField?
+    private var shadowLabel: NSTextField?
     private var imagePresetButtons: [NSButton] = []
+    private let popoverWidth: CGFloat = 300
+    private let compactPopoverHeight: CGFloat = 250
+    private let imagePopoverHeight: CGFloat = 452
 
     private let solidPresets: [(String, String)] = [
         ("Porcelain", "#f4eadb"),
@@ -653,7 +662,7 @@ private final class BackgroundPopoverController: NSViewController {
     required init?(coder: NSCoder) { fatalError() }
 
     override func loadView() {
-        let container = NSView(frame: NSRect(x: 0, y: 0, width: 300, height: 452))
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: popoverWidth, height: imagePopoverHeight))
         var y: CGFloat = 416
 
         enabledButton.frame = NSRect(x: 16, y: y, width: 260, height: 22)
@@ -662,7 +671,7 @@ private final class BackgroundPopoverController: NSViewController {
         container.addSubview(enabledButton)
 
         y -= 38
-        addLabel("Style", x: 16, y: y + 4, to: container)
+        styleLabel = addLabel("Style", x: 16, y: y + 4, to: container)
         stylePopup.frame = NSRect(x: 106, y: y, width: 170, height: 26)
         stylePopup.addItems(withTitles: ["Gradient", "Solid Color", "Image"])
         stylePopup.target = self
@@ -688,11 +697,11 @@ private final class BackgroundPopoverController: NSViewController {
         addImagePresetGrid(to: container)
 
         y = 124
-        addSliderRow("Padding", slider: paddingSlider, valueLabel: paddingValue, y: y, min: 0, max: 240, to: container)
+        paddingLabel = addSliderRow("Padding", slider: paddingSlider, valueLabel: paddingValue, y: y, min: 0, max: 240, to: container)
         y -= 38
-        addSliderRow("Radius", slider: radiusSlider, valueLabel: radiusValue, y: y, min: 0, max: 36, to: container)
+        radiusLabel = addSliderRow("Radius", slider: radiusSlider, valueLabel: radiusValue, y: y, min: 0, max: 36, to: container)
         y -= 38
-        addSliderRow("Shadow", slider: shadowSlider, valueLabel: shadowValue, y: y, min: 0, max: 1, to: container)
+        shadowLabel = addSliderRow("Shadow", slider: shadowSlider, valueLabel: shadowValue, y: y, min: 0, max: 1, to: container)
 
         view = container
         syncControls()
@@ -740,8 +749,9 @@ private final class BackgroundPopoverController: NSViewController {
         }
     }
 
-    private func addSliderRow(_ title: String, slider: NSSlider, valueLabel: NSTextField, y: CGFloat, min: Double, max: Double, to view: NSView) {
-        addLabel(title, x: 16, y: y + 6, to: view)
+    @discardableResult
+    private func addSliderRow(_ title: String, slider: NSSlider, valueLabel: NSTextField, y: CGFloat, min: Double, max: Double, to view: NSView) -> NSTextField {
+        let label = addLabel(title, x: 16, y: y + 6, to: view)
         slider.minValue = min
         slider.maxValue = max
         slider.target = self
@@ -753,6 +763,59 @@ private final class BackgroundPopoverController: NSViewController {
         valueLabel.textColor = .secondaryLabelColor
         valueLabel.frame = NSRect(x: 236, y: y + 5, width: 40, height: 16)
         view.addSubview(valueLabel)
+        return label
+    }
+
+    private func layoutControls() {
+        let isImageStyle = options.style == .image
+        let height = isImageStyle ? imagePopoverHeight : compactPopoverHeight
+        let size = NSSize(width: popoverWidth, height: height)
+        view.setFrameSize(size)
+        preferredContentSize = size
+        popover?.contentSize = size
+
+        let enabledY = height - 36
+        let styleY = enabledY - 38
+        let presetY = styleY - 36
+        let uploadY = presetY - 40
+        let imageGridStartY = uploadY - 46
+        let sliderY = isImageStyle ? CGFloat(124) : presetY - 48
+
+        enabledButton.frame = NSRect(x: 16, y: enabledY, width: 260, height: 22)
+        styleLabel?.frame = NSRect(x: 16, y: styleY + 4, width: 80, height: 16)
+        stylePopup.frame = NSRect(x: 106, y: styleY, width: 170, height: 26)
+        presetLabel?.frame = NSRect(x: 16, y: presetY + 4, width: 80, height: 16)
+        presetPopup.frame = NSRect(x: 106, y: presetY, width: 170, height: 26)
+        uploadImageButton.frame = NSRect(x: 16, y: uploadY, width: 260, height: 30)
+        layoutImagePresetButtons(startY: imageGridStartY)
+        layoutSliderRow(label: paddingLabel, slider: paddingSlider, valueLabel: paddingValue, y: sliderY)
+        layoutSliderRow(label: radiusLabel, slider: radiusSlider, valueLabel: radiusValue, y: sliderY - 38)
+        layoutSliderRow(label: shadowLabel, slider: shadowSlider, valueLabel: shadowValue, y: sliderY - 76)
+        view.needsDisplay = true
+    }
+
+    private func layoutImagePresetButtons(startY: CGFloat) {
+        let buttonSize = NSSize(width: 42, height: 34)
+        let gap: CGFloat = 10
+        let startX: CGFloat = 16
+        let columns = 5
+
+        for (index, button) in imagePresetButtons.enumerated() {
+            let row = index / columns
+            let col = index % columns
+            button.frame = NSRect(
+                x: startX + CGFloat(col) * (buttonSize.width + gap),
+                y: startY - CGFloat(row) * (buttonSize.height + gap),
+                width: buttonSize.width,
+                height: buttonSize.height
+            )
+        }
+    }
+
+    private func layoutSliderRow(label: NSTextField?, slider: NSSlider, valueLabel: NSTextField, y: CGFloat) {
+        label?.frame = NSRect(x: 16, y: y + 6, width: 80, height: 16)
+        slider.frame = NSRect(x: 106, y: y, width: 126, height: 26)
+        valueLabel.frame = NSRect(x: 236, y: y + 5, width: 40, height: 16)
     }
 
     private func syncControls() {
@@ -794,6 +857,7 @@ private final class BackgroundPopoverController: NSViewController {
 
     private func updateStyleVisibility() {
         let isImageStyle = options.style == .image
+        layoutControls()
         presetLabel?.isHidden = isImageStyle
         presetPopup.isHidden = isImageStyle
         uploadImageButton.isHidden = !isImageStyle
@@ -1097,6 +1161,10 @@ final class ColorPopoverController: NSViewController {
                 guard idx < presets.count else { break }
                 let x = padding + CGFloat(col) * (btnSize + gap)
                 let btn = NSButton(frame: NSRect(x: x, y: y, width: btnSize, height: btnSize))
+                btn.title = ""
+                btn.alternateTitle = ""
+                btn.attributedTitle = NSAttributedString(string: "")
+                btn.imagePosition = .noImage
                 btn.wantsLayer = true
                 btn.layer?.cornerRadius = btnSize / 2
                 btn.layer?.backgroundColor = presets[idx].cgColor

--- a/Sources/Shotnix/Annotation/AnnotationWindowController.swift
+++ b/Sources/Shotnix/Annotation/AnnotationWindowController.swift
@@ -6,7 +6,7 @@ import UniformTypeIdentifiers
 final class AnnotationWindowController: NSWindowController {
 
     private static let trafficLightReservedWidth: CGFloat = 92
-    private static let minimumEditorWidth = trafficLightReservedWidth + AnnotationToolbar.requiredWidth
+    private static let minimumEditorWidth = trafficLightReservedWidth + AnnotationToolbar.requiredWidth + 20
 
     private let canvas: AnnotationCanvas
     private let toolbar: AnnotationToolbar
@@ -57,12 +57,14 @@ final class AnnotationWindowController: NSWindowController {
         self.toolbar = AnnotationToolbar()
 
         let canvasSize = image.size
-        let toolbarHeight: CGFloat = 52
+        let toolbarHeight: CGFloat = 76
+        let toolbarDockHeight: CGFloat = 56
+        let stageInset: CGFloat = 18
 
         // Cap window to 85% of screen so large screenshots don't go off-screen
         let screenFrame = NSScreen.main?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1280, height: 800)
         let maxW = screenFrame.width * 0.85
-        let maxH = screenFrame.height * 0.85 - toolbarHeight
+        let maxH = screenFrame.height * 0.85 - toolbarHeight - stageInset
         let winW = max(min(canvasSize.width, maxW), Self.minimumEditorWidth)
         let winH = min(canvasSize.height, maxH) + toolbarHeight
         let windowSize = NSSize(width: winW, height: winH)
@@ -77,7 +79,7 @@ final class AnnotationWindowController: NSWindowController {
         win.titlebarAppearsTransparent = true
         win.isReleasedWhenClosed = false
         win.level = .floating
-        win.minSize = NSSize(width: Self.minimumEditorWidth, height: 240 + toolbarHeight)
+        win.minSize = NSSize(width: Self.minimumEditorWidth, height: 260 + toolbarHeight)
         win.center()
 
         super.init(window: win)
@@ -86,7 +88,12 @@ final class AnnotationWindowController: NSWindowController {
         canvas.frame = NSRect(origin: .zero, size: canvasSize)
 
         // Scroll view for canvas — clips content properly
-        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: winW, height: winH - toolbarHeight))
+        let scrollView = NSScrollView(frame: NSRect(
+            x: stageInset,
+            y: stageInset,
+            width: winW - stageInset * 2,
+            height: winH - toolbarHeight - stageInset
+        ))
         // Center canvas when viewport is larger than the image (eliminates blank side areas)
         let clipView = CenteringClipView()
         clipView.drawsBackground = false
@@ -95,20 +102,31 @@ final class AnnotationWindowController: NSWindowController {
         scrollView.hasVerticalScroller = true
         scrollView.hasHorizontalScroller = true
         scrollView.autohidesScrollers = true
-        scrollView.drawsBackground = true
-        scrollView.backgroundColor = ShotnixColors.canvasBackground
+        scrollView.drawsBackground = false
+        scrollView.backgroundColor = .clear
         scrollView.autoresizingMask = [.width, .height]
         scrollView.horizontalScrollElasticity = .none
         scrollView.verticalScrollElasticity = .none
+        scrollView.wantsLayer = true
+        scrollView.layer?.cornerRadius = 18
+        scrollView.layer?.cornerCurve = .continuous
+        scrollView.layer?.borderWidth = 1
+        scrollView.layer?.borderColor = ShotnixColors.editorChromeBorder.cgColor
+        scrollView.layer?.shadowColor = NSColor.black.cgColor
+        scrollView.layer?.shadowOpacity = 0.24
+        scrollView.layer?.shadowRadius = 32
+        scrollView.layer?.shadowOffset = CGSize(width: 0, height: -18)
 
-        // Toolbar positioned at top of window
+        // Floating toolbar dock positioned at top of window
+        let toolbarWidth = min(AnnotationToolbar.requiredWidth, max(0, winW - Self.trafficLightReservedWidth - stageInset))
+        let toolbarX = max(Self.trafficLightReservedWidth, round((winW - toolbarWidth) / 2))
         toolbar.frame = NSRect(
-            x: Self.trafficLightReservedWidth,
-            y: winH - toolbarHeight,
-            width: max(0, winW - Self.trafficLightReservedWidth),
-            height: toolbarHeight
+            x: toolbarX,
+            y: winH - toolbarDockHeight - 10,
+            width: toolbarWidth,
+            height: toolbarDockHeight
         )
-        toolbar.autoresizingMask = [.width, .minYMargin]
+        toolbar.autoresizingMask = [.minXMargin, .maxXMargin, .minYMargin]
 
         toolbar.onToolChanged     = { [weak self] tool in
             self?.canvas.activeTool = tool
@@ -143,7 +161,7 @@ final class AnnotationWindowController: NSWindowController {
         }
 
         // Build hierarchy FIRST, then configure layers (layers don't exist until views are in a window)
-        let container = NSView(frame: NSRect(origin: .zero, size: windowSize))
+        let container = PremiumEditorStageView(frame: NSRect(origin: .zero, size: windowSize))
         container.addSubview(scrollView)
         container.addSubview(toolbar)
         win.contentView = container
@@ -278,6 +296,52 @@ final class CenteringClipView: NSClipView {
     }
 }
 
+@MainActor
+private final class PremiumEditorStageView: NSView {
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func draw(_ dirtyRect: NSRect) {
+        guard let ctx = NSGraphicsContext.current?.cgContext else { return }
+        let rect = bounds
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+        let colors = [ShotnixColors.editorStageTop.cgColor, ShotnixColors.editorStageBottom.cgColor] as CFArray
+
+        if let gradient = CGGradient(colorsSpace: colorSpace, colors: colors, locations: [0, 1]) {
+            ctx.drawLinearGradient(
+                gradient,
+                start: CGPoint(x: rect.midX, y: rect.minY),
+                end: CGPoint(x: rect.midX, y: rect.maxY),
+                options: []
+            )
+        } else {
+            ShotnixColors.editorStageTop.setFill()
+            rect.fill()
+        }
+
+        drawGlow(in: ctx, rect: rect, color: NSColor.controlAccentColor.withAlphaComponent(0.18), center: CGPoint(x: rect.maxX * 0.72, y: rect.minY + 24), radius: max(rect.width, rect.height) * 0.42)
+        drawGlow(in: ctx, rect: rect, color: NSColor.systemPurple.withAlphaComponent(0.12), center: CGPoint(x: rect.minX + rect.width * 0.18, y: rect.maxY + 20), radius: max(rect.width, rect.height) * 0.36)
+    }
+
+    private func drawGlow(in context: CGContext, rect: CGRect, color: NSColor, center: CGPoint, radius: CGFloat) {
+        let colors = [color.cgColor, color.withAlphaComponent(0).cgColor] as CFArray
+        let colorSpace = color.cgColor.colorSpace ?? CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+        guard let gradient = CGGradient(colorsSpace: colorSpace, colors: colors, locations: [0, 1]) else { return }
+        context.drawRadialGradient(
+            gradient,
+            startCenter: center,
+            startRadius: 0,
+            endCenter: center,
+            endRadius: radius,
+            options: .drawsAfterEndLocation
+        )
+    }
+}
+
 // MARK: – Toolbar
 
 @MainActor
@@ -311,21 +375,32 @@ final class AnnotationToolbar: NSView {
 
     private func buildUI() {
         wantsLayer = true
+        layer?.cornerRadius = 18
+        layer?.cornerCurve = .continuous
+        layer?.shadowColor = NSColor.black.cgColor
+        layer?.shadowOpacity = 0.18
+        layer?.shadowRadius = 22
+        layer?.shadowOffset = CGSize(width: 0, height: -10)
 
-        // Frosted glass background
         let blur = NSVisualEffectView(frame: bounds)
-        blur.material = .titlebar
+        blur.material = .hudWindow
         blur.blendingMode = .withinWindow
         blur.state = .active
         blur.autoresizingMask = [.width, .height]
+        blur.wantsLayer = true
+        blur.layer?.cornerRadius = 18
+        blur.layer?.cornerCurve = .continuous
+        blur.layer?.masksToBounds = true
         addSubview(blur)
 
-        // Bottom separator line
-        let bottomLine = NSBox()
-        bottomLine.boxType = .separator
-        bottomLine.frame = NSRect(x: 0, y: 0, width: bounds.width, height: 1)
-        bottomLine.autoresizingMask = [.width]
-        addSubview(bottomLine)
+        let border = NSView(frame: bounds.insetBy(dx: 0.5, dy: 0.5))
+        border.autoresizingMask = [.width, .height]
+        border.wantsLayer = true
+        border.layer?.cornerRadius = 18
+        border.layer?.cornerCurve = .continuous
+        border.layer?.borderWidth = 1
+        border.layer?.borderColor = ShotnixColors.editorDockBorder.cgColor
+        addSubview(border)
 
         var x: CGFloat = 8
 
@@ -400,8 +475,8 @@ final class AnnotationToolbar: NSView {
 
         x += 10
 
-        let backgroundBtn = NSButton(title: "Backdrop", target: self, action: #selector(backgroundTapped(_:)))
-        backgroundBtn.bezelStyle = .rounded
+        let backgroundBtn = PremiumToolbarActionButton(title: "Backdrop", target: self, action: #selector(backgroundTapped(_:)))
+        backgroundBtn.bezelStyle = .regularSquare
         backgroundBtn.font = .systemFont(ofSize: 11, weight: .semibold)
         backgroundBtn.image = NSImage(systemSymbolName: "sparkles", accessibilityDescription: nil)
         backgroundBtn.imagePosition = .imageLeading
@@ -414,16 +489,16 @@ final class AnnotationToolbar: NSView {
 
         // Action buttons
         for (title, sel) in [("Copy", #selector(copyTapped)), ("Save", #selector(saveTapped))] {
-            let btn = NSButton(title: title, target: self, action: sel)
-            btn.bezelStyle = .rounded
+            let btn = PremiumToolbarActionButton(title: title, target: self, action: sel)
+            btn.bezelStyle = .regularSquare
             btn.font = .systemFont(ofSize: 11, weight: title == "Save" ? .semibold : .regular)
             btn.frame = NSRect(x: x, y: 10, width: 54, height: 30)
             addSubview(btn); x += 58
         }
 
         // Crop apply button (only visible when a crop region is drawn)
-        let cropBtn = NSButton(title: "Crop\u{2713}", target: self, action: #selector(cropTapped))
-        cropBtn.bezelStyle = .rounded
+        let cropBtn = PremiumToolbarActionButton(title: "Crop\u{2713}", target: self, action: #selector(cropTapped))
+        cropBtn.bezelStyle = .regularSquare
         cropBtn.font = .systemFont(ofSize: 11)
         cropBtn.frame = NSRect(x: x, y: 11, width: 60, height: 28)
         cropBtn.isHidden = true
@@ -918,6 +993,75 @@ private final class AnnotationToolButton: NSButton {
         layer?.add(spring, forKey: "bounceBack")
         layer?.transform = CATransform3DIdentity
         super.mouseUp(with: event)
+    }
+}
+
+@MainActor
+private final class PremiumToolbarActionButton: NSButton {
+    private var trackingArea: NSTrackingArea?
+    private var isHovered = false
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        configureLayer()
+    }
+
+    convenience init(title: String, target: AnyObject?, action: Selector?) {
+        self.init(frame: .zero)
+        self.title = title
+        self.target = target
+        self.action = action
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let trackingArea { removeTrackingArea(trackingArea) }
+        let area = NSTrackingArea(rect: bounds, options: [.activeAlways, .mouseEnteredAndExited], owner: self)
+        addTrackingArea(area)
+        trackingArea = area
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        isHovered = true
+        animateBackground(ShotnixColors.cornerButtonHover.cgColor)
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        isHovered = false
+        animateBackground(ShotnixColors.editorActionBackground.cgColor)
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        animateBackground(ShotnixColors.cornerButtonPressed.cgColor)
+        layer?.transform = CATransform3DMakeScale(0.97, 0.97, 1)
+        super.mouseDown(with: event)
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        animateBackground(isHovered ? ShotnixColors.cornerButtonHover.cgColor : ShotnixColors.editorActionBackground.cgColor)
+        layer?.transform = CATransform3DIdentity
+        super.mouseUp(with: event)
+    }
+
+    private func configureLayer() {
+        wantsLayer = true
+        isBordered = false
+        layer?.cornerRadius = 9
+        layer?.cornerCurve = .continuous
+        layer?.backgroundColor = ShotnixColors.editorActionBackground.cgColor
+        layer?.borderWidth = 1
+        layer?.borderColor = ShotnixColors.editorDockBorder.cgColor
+    }
+
+    private func animateBackground(_ color: CGColor) {
+        wantsLayer = true
+        NSAnimationContext.runAnimationGroup { ctx in
+            ctx.duration = 0.16
+            ctx.allowsImplicitAnimation = true
+            self.layer?.backgroundColor = color
+        }
     }
 }
 

--- a/Sources/Shotnix/Annotation/AnnotationWindowController.swift
+++ b/Sources/Shotnix/Annotation/AnnotationWindowController.swift
@@ -1,4 +1,5 @@
 import AppKit
+import UniformTypeIdentifiers
 
 /// Manages the full annotation editor window.
 @MainActor
@@ -537,12 +538,15 @@ private final class BackgroundPopoverController: NSViewController {
     private let enabledButton = NSButton(checkboxWithTitle: "Apply background to this image", target: nil, action: nil)
     private let stylePopup = NSPopUpButton()
     private let presetPopup = NSPopUpButton()
+    private let uploadImageButton = NSButton(title: "Upload Custom Image", target: nil, action: nil)
     private let paddingSlider = NSSlider()
     private let radiusSlider = NSSlider()
     private let shadowSlider = NSSlider()
     private let paddingValue = NSTextField(labelWithString: "")
     private let radiusValue = NSTextField(labelWithString: "")
     private let shadowValue = NSTextField(labelWithString: "")
+    private var presetLabel: NSTextField?
+    private var imagePresetButtons: [NSButton] = []
 
     private let solidPresets: [(String, String)] = [
         ("Porcelain", "#f4eadb"),
@@ -574,8 +578,8 @@ private final class BackgroundPopoverController: NSViewController {
     required init?(coder: NSCoder) { fatalError() }
 
     override func loadView() {
-        let container = NSView(frame: NSRect(x: 0, y: 0, width: 300, height: 230))
-        var y: CGFloat = 194
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: 300, height: 452))
+        var y: CGFloat = 416
 
         enabledButton.frame = NSRect(x: 16, y: y, width: 260, height: 22)
         enabledButton.target = self
@@ -585,19 +589,30 @@ private final class BackgroundPopoverController: NSViewController {
         y -= 38
         addLabel("Style", x: 16, y: y + 4, to: container)
         stylePopup.frame = NSRect(x: 106, y: y, width: 170, height: 26)
-        stylePopup.addItems(withTitles: ["Gradient", "Solid Color"])
+        stylePopup.addItems(withTitles: ["Gradient", "Solid Color", "Image"])
         stylePopup.target = self
         stylePopup.action = #selector(styleChanged)
         container.addSubview(stylePopup)
 
         y -= 36
-        addLabel("Preset", x: 16, y: y + 4, to: container)
+        presetLabel = addLabel("Preset", x: 16, y: y + 4, to: container)
         presetPopup.frame = NSRect(x: 106, y: y, width: 170, height: 26)
         presetPopup.target = self
         presetPopup.action = #selector(presetChanged)
         container.addSubview(presetPopup)
 
-        y -= 42
+        uploadImageButton.frame = NSRect(x: 16, y: 302, width: 260, height: 30)
+        uploadImageButton.bezelStyle = .rounded
+        uploadImageButton.font = .systemFont(ofSize: 12, weight: .semibold)
+        uploadImageButton.image = NSImage(systemSymbolName: "square.and.arrow.up", accessibilityDescription: nil)
+        uploadImageButton.imagePosition = .imageLeading
+        uploadImageButton.target = self
+        uploadImageButton.action = #selector(uploadCustomImage)
+        container.addSubview(uploadImageButton)
+
+        addImagePresetGrid(to: container)
+
+        y = 124
         addSliderRow("Padding", slider: paddingSlider, valueLabel: paddingValue, y: y, min: 0, max: 240, to: container)
         y -= 38
         addSliderRow("Radius", slider: radiusSlider, valueLabel: radiusValue, y: y, min: 0, max: 36, to: container)
@@ -608,11 +623,46 @@ private final class BackgroundPopoverController: NSViewController {
         syncControls()
     }
 
-    private func addLabel(_ text: String, x: CGFloat, y: CGFloat, to view: NSView) {
+    @discardableResult
+    private func addLabel(_ text: String, x: CGFloat, y: CGFloat, to view: NSView) -> NSTextField {
         let label = NSTextField(labelWithString: text)
         label.font = .systemFont(ofSize: 11)
         label.frame = NSRect(x: x, y: y, width: 80, height: 16)
         view.addSubview(label)
+        return label
+    }
+
+    private func addImagePresetGrid(to view: NSView) {
+        let buttonSize = NSSize(width: 42, height: 34)
+        let gap: CGFloat = 10
+        let startX: CGFloat = 16
+        let startY: CGFloat = 256
+        let columns = 5
+
+        for (index, preset) in ScreenshotBackgroundOptions.imagePresets.enumerated() {
+            let row = index / columns
+            let col = index % columns
+            let button = NSButton(frame: NSRect(
+                x: startX + CGFloat(col) * (buttonSize.width + gap),
+                y: startY - CGFloat(row) * (buttonSize.height + gap),
+                width: buttonSize.width,
+                height: buttonSize.height
+            ))
+            button.image = ScreenshotBackgroundComposer.previewImage(options: imageOptions(for: preset), size: NSSize(width: 84, height: 68))
+            button.imageScaling = .scaleAxesIndependently
+            button.isBordered = false
+            button.bezelStyle = .regularSquare
+            button.toolTip = preset.name
+            button.tag = index
+            button.target = self
+            button.action = #selector(imagePresetTapped(_:))
+            button.wantsLayer = true
+            button.layer?.cornerRadius = 7
+            button.layer?.cornerCurve = .continuous
+            button.layer?.masksToBounds = true
+            view.addSubview(button)
+            imagePresetButtons.append(button)
+        }
     }
 
     private func addSliderRow(_ title: String, slider: NSSlider, valueLabel: NSTextField, y: CGFloat, min: Double, max: Double, to view: NSView) {
@@ -632,12 +682,18 @@ private final class BackgroundPopoverController: NSViewController {
 
     private func syncControls() {
         enabledButton.state = options.isEnabled ? .on : .off
-        stylePopup.selectItem(at: options.style == .gradient ? 0 : 1)
+        switch options.style {
+        case .gradient: stylePopup.selectItem(at: 0)
+        case .solid: stylePopup.selectItem(at: 1)
+        case .image: stylePopup.selectItem(at: 2)
+        }
         paddingSlider.doubleValue = Double(options.padding)
         radiusSlider.doubleValue = Double(options.cornerRadius)
         shadowSlider.doubleValue = Double(options.shadow)
         rebuildPresetPopup()
+        updateStyleVisibility()
         updateValueLabels()
+        updateImagePresetSelection()
     }
 
     private func rebuildPresetPopup() {
@@ -653,6 +709,29 @@ private final class BackgroundPopoverController: NSViewController {
             if let index = gradientPresets.firstIndex(where: { $0.name == options.presetName }) {
                 presetPopup.selectItem(at: index)
             }
+        case .image:
+            presetPopup.addItems(withTitles: ScreenshotBackgroundOptions.imagePresets.map(\.name))
+            if let index = ScreenshotBackgroundOptions.imagePresets.firstIndex(where: { $0.name == options.presetName }) {
+                presetPopup.selectItem(at: index)
+            }
+        }
+    }
+
+    private func updateStyleVisibility() {
+        let isImageStyle = options.style == .image
+        presetLabel?.isHidden = isImageStyle
+        presetPopup.isHidden = isImageStyle
+        uploadImageButton.isHidden = !isImageStyle
+        imagePresetButtons.forEach { $0.isHidden = !isImageStyle }
+        uploadImageButton.title = options.customImageName.map { "Custom: \($0)" } ?? "Upload Custom Image"
+    }
+
+    private func updateImagePresetSelection() {
+        for (index, button) in imagePresetButtons.enumerated() {
+            let preset = ScreenshotBackgroundOptions.imagePresets[index]
+            let selected = options.style == .image && options.customImageData == nil && preset.name == options.presetName
+            button.layer?.borderWidth = selected ? 2 : 1
+            button.layer?.borderColor = selected ? NSColor.controlAccentColor.cgColor : NSColor.white.withAlphaComponent(0.18).cgColor
         }
     }
 
@@ -663,6 +742,8 @@ private final class BackgroundPopoverController: NSViewController {
     }
 
     private func emitChange() {
+        updateStyleVisibility()
+        updateImagePresetSelection()
         updateValueLabels()
         onChange?(options)
     }
@@ -673,9 +754,29 @@ private final class BackgroundPopoverController: NSViewController {
     }
 
     @objc private func styleChanged() {
-        options.style = stylePopup.indexOfSelectedItem == 0 ? .gradient : .solid
+        switch stylePopup.indexOfSelectedItem {
+        case 1:
+            options.style = .solid
+        case 2:
+            options.style = .image
+            options.isEnabled = true
+            if options.customImageData == nil,
+               !ScreenshotBackgroundOptions.imagePresets.contains(where: { $0.name == options.presetName }) {
+                let preset = ScreenshotBackgroundOptions.imagePresets[0]
+                options.presetName = preset.name
+                options.gradientStartHex = preset.startHex
+                options.gradientEndHex = preset.endHex
+                options.accentHexes = preset.accentHexes
+            }
+        default:
+            options.style = .gradient
+        }
         rebuildPresetPopup()
-        presetChanged()
+        if options.style == .image {
+            emitChange()
+        } else {
+            presetChanged()
+        }
     }
 
     @objc private func presetChanged() {
@@ -692,8 +793,64 @@ private final class BackgroundPopoverController: NSViewController {
             options.gradientStartHex = preset.start
             options.gradientEndHex = preset.end
             options.accentHexes = preset.accents
+            options.customImageData = nil
+            options.customImageName = nil
+        case .image:
+            let preset = ScreenshotBackgroundOptions.imagePresets[min(index, ScreenshotBackgroundOptions.imagePresets.count - 1)]
+            applyImagePreset(preset)
         }
         emitChange()
+    }
+
+    @objc private func imagePresetTapped(_ sender: NSButton) {
+        let preset = ScreenshotBackgroundOptions.imagePresets[min(sender.tag, ScreenshotBackgroundOptions.imagePresets.count - 1)]
+        applyImagePreset(preset)
+        emitChange()
+    }
+
+    @objc private func uploadCustomImage() {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.image]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+
+        guard panel.runModal() == .OK,
+              let url = panel.url,
+              let data = try? Data(contentsOf: url),
+              NSImage(data: data) != nil else { return }
+
+        options.isEnabled = true
+        options.style = .image
+        options.presetName = "Custom Image"
+        options.customImageData = data
+        options.customImageName = url.lastPathComponent
+        stylePopup.selectItem(at: 2)
+        emitChange()
+    }
+
+    private func applyImagePreset(_ preset: ScreenshotBackgroundImagePreset) {
+        options.isEnabled = true
+        options.style = .image
+        options.presetName = preset.name
+        options.gradientStartHex = preset.startHex
+        options.gradientEndHex = preset.endHex
+        options.accentHexes = preset.accentHexes
+        options.customImageData = nil
+        options.customImageName = nil
+    }
+
+    private func imageOptions(for preset: ScreenshotBackgroundImagePreset) -> ScreenshotBackgroundOptions {
+        var preview = options
+        preview.isEnabled = true
+        preview.style = .image
+        preview.presetName = preset.name
+        preview.gradientStartHex = preset.startHex
+        preview.gradientEndHex = preset.endHex
+        preview.accentHexes = preset.accentHexes
+        preview.customImageData = nil
+        preview.customImageName = nil
+        return preview
     }
 
     @objc private func sliderChanged(_ sender: NSSlider) {

--- a/Sources/Shotnix/App/PreferencesWindowController.swift
+++ b/Sources/Shotnix/App/PreferencesWindowController.swift
@@ -352,7 +352,7 @@ struct RecordingSettingsView: View {
 }
 
 struct AboutSettingsView: View {
-    let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.11.0-beta"
+    let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.12.0-beta"
     
     var body: some View {
         VStack(alignment: .center, spacing: 16) {
@@ -377,6 +377,11 @@ struct AboutSettingsView: View {
                 
                 ScrollView {
                     Text("""
+                    Version 0.12.0-beta
+                    • Custom image backdrops and generated image presets for presentation-ready exports
+                    • Refined annotation editor chrome, toolbar spacing, and background popovers
+                    • Numbered markers and color swatches render cleanly in the editor
+
                     Version 0.11.0-beta
                     • Per-image Backdrop controls for presentation-ready screenshot exports
                     • Annotation editor now previews styled backgrounds exactly as saved

--- a/Sources/Shotnix/Utilities/AdaptiveColors.swift
+++ b/Sources/Shotnix/Utilities/AdaptiveColors.swift
@@ -96,6 +96,41 @@ enum ShotnixColors {
         }
     }
 
+    static let editorStageTop = NSColor(name: "editorStageTop") { appearance in
+        switch appearance.bestMatch(from: [.aqua, .darkAqua]) {
+        case .darkAqua: return NSColor(calibratedRed: 0.045, green: 0.049, blue: 0.062, alpha: 1)
+        default:        return NSColor(calibratedRed: 0.16, green: 0.17, blue: 0.19, alpha: 1)
+        }
+    }
+
+    static let editorStageBottom = NSColor(name: "editorStageBottom") { appearance in
+        switch appearance.bestMatch(from: [.aqua, .darkAqua]) {
+        case .darkAqua: return NSColor(calibratedRed: 0.105, green: 0.096, blue: 0.13, alpha: 1)
+        default:        return NSColor(calibratedRed: 0.28, green: 0.28, blue: 0.31, alpha: 1)
+        }
+    }
+
+    static let editorChromeBorder = NSColor(name: "editorChromeBorder") { appearance in
+        switch appearance.bestMatch(from: [.aqua, .darkAqua]) {
+        case .darkAqua: return NSColor.white.withAlphaComponent(0.10)
+        default:        return NSColor.white.withAlphaComponent(0.20)
+        }
+    }
+
+    static let editorDockBorder = NSColor(name: "editorDockBorder") { appearance in
+        switch appearance.bestMatch(from: [.aqua, .darkAqua]) {
+        case .darkAqua: return NSColor.white.withAlphaComponent(0.18)
+        default:        return NSColor.white.withAlphaComponent(0.28)
+        }
+    }
+
+    static let editorActionBackground = NSColor(name: "editorActionBackground") { appearance in
+        switch appearance.bestMatch(from: [.aqua, .darkAqua]) {
+        case .darkAqua: return NSColor.white.withAlphaComponent(0.13)
+        default:        return NSColor.black.withAlphaComponent(0.10)
+        }
+    }
+
     static let selectionDim = NSColor(name: "selectionDim") { appearance in
         switch appearance.bestMatch(from: [.aqua, .darkAqua]) {
         case .darkAqua: return NSColor.black.withAlphaComponent(0.45)

--- a/Sources/Shotnix/Utilities/ScreenshotBackgroundComposer.swift
+++ b/Sources/Shotnix/Utilities/ScreenshotBackgroundComposer.swift
@@ -4,6 +4,7 @@ struct ScreenshotBackgroundOptions: Equatable {
     enum Style: String {
         case solid
         case gradient
+        case image
     }
 
     var isEnabled: Bool
@@ -13,9 +14,29 @@ struct ScreenshotBackgroundOptions: Equatable {
     var gradientStartHex: String
     var gradientEndHex: String
     var accentHexes: [String]
+    var customImageData: Data?
+    var customImageName: String?
     var padding: CGFloat
     var cornerRadius: CGFloat
     var shadow: CGFloat
+
+    static let imagePresets: [ScreenshotBackgroundImagePreset] = [
+        .init(name: "Amber Fold", startHex: "#1c0b0f", endHex: "#f46f2f", accentHexes: ["#ffb45a", "#7b2dff", "#f93673"]),
+        .init(name: "Cobalt Drapes", startHex: "#071425", endHex: "#1b6dff", accentHexes: ["#ff7a3d", "#8cb7ff", "#3514b8"]),
+        .init(name: "Crimson Ridge", startHex: "#250617", endHex: "#f05b55", accentHexes: ["#ffb24a", "#7a2cff", "#ff4fa3"]),
+        .init(name: "Night Current", startHex: "#050714", endHex: "#4656c6", accentHexes: ["#c33a5d", "#0f2149", "#5b8dff"]),
+        .init(name: "Tide Glass", startHex: "#0a2432", endHex: "#5fb6d9", accentHexes: ["#f0664f", "#103b66", "#b4e8ff"]),
+        .init(name: "Desert Violet", startHex: "#261126", endHex: "#dc6b8d", accentHexes: ["#ff8d4a", "#7d3cff", "#f6d6b7"]),
+        .init(name: "Rose Smoke", startHex: "#381631", endHex: "#f095bb", accentHexes: ["#ffcfcc", "#8033a8", "#f1597f"]),
+        .init(name: "Lime Signal", startHex: "#0c1710", endHex: "#9fd72a", accentHexes: ["#25a36f", "#f2ff8a", "#395ed8"]),
+        .init(name: "Violet Bloom", startHex: "#10081e", endHex: "#8d4cff", accentHexes: ["#f06ab9", "#6645ff", "#f0ddff"]),
+        .init(name: "Canyon Silk", startHex: "#2b150d", endHex: "#e8a75d", accentHexes: ["#f66547", "#ffd4a8", "#6067ff"]),
+        .init(name: "Pine Dusk", startHex: "#081a1f", endHex: "#173b3d", accentHexes: ["#88a9a5", "#0d2d38", "#1a535c"]),
+        .init(name: "Aqua Marble", startHex: "#dff9f4", endHex: "#efc6d8", accentHexes: ["#61d1ca", "#ff8dac", "#ffffff"]),
+        .init(name: "Sky Wash", startHex: "#cbe8ff", endHex: "#f0c28a", accentHexes: ["#6db4ff", "#f27b5b", "#ffffff"]),
+        .init(name: "Carbon Arc", startHex: "#06070d", endHex: "#202944", accentHexes: ["#d3345d", "#4c73ff", "#ffb16f"]),
+        .init(name: "Prism Sweep", startHex: "#07151c", endHex: "#f5d765", accentHexes: ["#20c7b4", "#f9687d", "#397cff"])
+    ]
 
     static let editorDefault = ScreenshotBackgroundOptions(
         isEnabled: false,
@@ -25,10 +46,19 @@ struct ScreenshotBackgroundOptions: Equatable {
         gradientStartHex: "#6a2cff",
         gradientEndHex: "#ffd36a",
         accentHexes: ["#ff7ac8", "#6af7ff", "#fff6b0"],
+        customImageData: nil,
+        customImageName: nil,
         padding: 72,
         cornerRadius: 18,
         shadow: 0.32
     )
+}
+
+struct ScreenshotBackgroundImagePreset: Equatable {
+    let name: String
+    let startHex: String
+    let endHex: String
+    let accentHexes: [String]
 }
 
 enum ScreenshotBackgroundComposer {
@@ -91,7 +121,39 @@ enum ScreenshotBackgroundComposer {
         return output
     }
 
+    static func previewImage(options: ScreenshotBackgroundOptions, size: NSSize) -> NSImage {
+        let pixelWidth = max(1, Int(ceil(size.width * 2)))
+        let pixelHeight = max(1, Int(ceil(size.height * 2)))
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+        guard let context = CGContext(
+            data: nil,
+            width: pixelWidth,
+            height: pixelHeight,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return NSImage(size: size) }
+
+        context.scaleBy(x: 2, y: 2)
+        context.interpolationQuality = .high
+        drawBackground(in: context, rect: CGRect(origin: .zero, size: size), options: options)
+
+        guard let preview = context.makeImage() else { return NSImage(size: size) }
+        let rep = NSBitmapImageRep(cgImage: preview)
+        rep.size = size
+        let image = NSImage(size: size)
+        image.addRepresentation(rep)
+        return image
+    }
+
     private static func drawBackground(in context: CGContext, rect: CGRect, options: ScreenshotBackgroundOptions) {
+        if options.style == .image {
+            drawImageBackground(in: context, rect: rect, options: options)
+            drawVignette(in: context, rect: rect)
+            return
+        }
+
         if options.style == .gradient {
             let start = color(from: options.gradientStartHex)
             let end = color(from: options.gradientEndHex)
@@ -113,6 +175,89 @@ enum ScreenshotBackgroundComposer {
         context.setFillColor(color(from: options.colorHex).cgColor)
         context.fill(rect)
         drawVignette(in: context, rect: rect)
+    }
+
+    private static func drawImageBackground(in context: CGContext, rect: CGRect, options: ScreenshotBackgroundOptions) {
+        if let data = options.customImageData,
+           let image = NSImage(data: data),
+           let cgImage = image.bestCGImage {
+            context.draw(cgImage, in: aspectFillRect(for: CGSize(width: cgImage.width, height: cgImage.height), in: rect))
+            return
+        }
+
+        let preset = ScreenshotBackgroundOptions.imagePresets.first { $0.name == options.presetName }
+            ?? ScreenshotBackgroundOptions.imagePresets[0]
+        drawPresetImageBackground(in: context, rect: rect, preset: preset)
+    }
+
+    private static func drawPresetImageBackground(in context: CGContext, rect: CGRect, preset: ScreenshotBackgroundImagePreset) {
+        let start = color(from: preset.startHex)
+        let end = color(from: preset.endHex)
+        let colorSpace = start.cgColor.colorSpace ?? CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+        if let gradient = CGGradient(colorsSpace: colorSpace, colors: [start.cgColor, end.cgColor] as CFArray, locations: [0, 1]) {
+            context.drawLinearGradient(
+                gradient,
+                start: CGPoint(x: rect.minX, y: rect.minY + rect.height * 0.15),
+                end: CGPoint(x: rect.maxX, y: rect.maxY),
+                options: []
+            )
+        } else {
+            context.setFillColor(start.cgColor)
+            context.fill(rect)
+        }
+
+        let accents = preset.accentHexes.map(color(from:))
+        for (index, accent) in accents.enumerated() {
+            let center = presetCenter(in: rect, index: index)
+            let radius = max(rect.width, rect.height) * (index == 0 ? 0.72 : 0.52)
+            drawGradientGlow(in: context, rect: rect, color: accent, center: center, radius: radius, alpha: index == 0 ? 0.38 : 0.28)
+        }
+
+        for index in 0..<3 {
+            drawSilkBand(in: context, rect: rect, color: accents[index % max(accents.count, 1)], index: index)
+        }
+    }
+
+    private static func presetCenter(in rect: CGRect, index: Int) -> CGPoint {
+        let centers = [
+            CGPoint(x: rect.minX + rect.width * 0.18, y: rect.minY + rect.height * 0.78),
+            CGPoint(x: rect.minX + rect.width * 0.82, y: rect.minY + rect.height * 0.24),
+            CGPoint(x: rect.minX + rect.width * 0.56, y: rect.minY + rect.height * 0.58),
+            CGPoint(x: rect.minX + rect.width * 0.28, y: rect.minY + rect.height * 0.18)
+        ]
+        return centers[index % centers.count]
+    }
+
+    private static func drawSilkBand(in context: CGContext, rect: CGRect, color: NSColor, index: Int) {
+        let offset = CGFloat(index) * rect.height * 0.16
+        let path = CGMutablePath()
+        path.move(to: CGPoint(x: rect.minX - rect.width * 0.18, y: rect.midY - rect.height * 0.18 + offset))
+        path.addCurve(
+            to: CGPoint(x: rect.maxX + rect.width * 0.18, y: rect.midY + rect.height * 0.06 + offset),
+            control1: CGPoint(x: rect.minX + rect.width * 0.22, y: rect.minY - rect.height * 0.10 + offset),
+            control2: CGPoint(x: rect.midX + rect.width * 0.12, y: rect.maxY + rect.height * 0.18 + offset)
+        )
+        path.addLine(to: CGPoint(x: rect.maxX + rect.width * 0.18, y: rect.midY + rect.height * 0.34 + offset))
+        path.addCurve(
+            to: CGPoint(x: rect.minX - rect.width * 0.18, y: rect.midY + rect.height * 0.08 + offset),
+            control1: CGPoint(x: rect.midX + rect.width * 0.16, y: rect.maxY + rect.height * 0.42 + offset),
+            control2: CGPoint(x: rect.minX + rect.width * 0.18, y: rect.minY + rect.height * 0.24 + offset)
+        )
+        path.closeSubpath()
+
+        context.saveGState()
+        context.addPath(path)
+        context.setFillColor(color.withAlphaComponent(0.16).cgColor)
+        context.fillPath()
+        context.restoreGState()
+    }
+
+    private static func aspectFillRect(for imageSize: CGSize, in rect: CGRect) -> CGRect {
+        guard imageSize.width > 0, imageSize.height > 0 else { return rect }
+        let scale = max(rect.width / imageSize.width, rect.height / imageSize.height)
+        let width = imageSize.width * scale
+        let height = imageSize.height * scale
+        return CGRect(x: rect.midX - width / 2, y: rect.midY - height / 2, width: width, height: height)
     }
 
     private static func drawProceduralBlooms(in context: CGContext, rect: CGRect, options: ScreenshotBackgroundOptions, start: NSColor, end: NSColor) {


### PR DESCRIPTION
## Summary
- Add generated image-style and custom image backdrops for annotation exports.
- Polish the annotation editor shell, toolbar spacing, background popover layout, color swatches, and numbered marker rendering.
- Prepare app metadata and docs for v0.12.0-beta.

## Verification
- LSP diagnostics clean for changed Swift files
- swift build
- swift test (no Tests target configured)
- bash build-app.sh
- bash make-dmg.sh
- codesign --verify --deep --strict --verbose=2 /Applications/Shotnix.app
- hdiutil verify Shotnix-v0.12.0-beta-macOS.dmg
- GIT_MASTER=1 git diff --check