### PR TITLE
Default screenshots to clipboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.14.0-beta] - 2026-05-12
+
+### Changed
+- **Default screenshot copy** — new screenshots are now copied to the clipboard by default, with a Screenshots preference to disable automatic copying.
+
 ## [0.13.0-beta] - 2026-05-11
 
 ### Changed

--- a/Info.plist
+++ b/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleDisplayName</key>
     <string>Shotnix</string>
     <key>CFBundleVersion</key>
-    <string>16</string>
+    <string>17</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.13.0-beta</string>
+    <string>0.14.0-beta</string>
     <key>CFBundleExecutable</key>
     <string>Shotnix</string>
     <key>CFBundlePackageType</key>

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ---
 
 > [!NOTE]
-> **Shotnix is in beta (v0.13.0-beta).** It's fully functional but not yet notarized through Apple's Developer Program, so macOS will show a Gatekeeper warning on first launch. This is standard for open-source apps — Shotnix is safe and the source code is right here. Notarization is on the roadmap.
+> **Shotnix is in beta (v0.14.0-beta).** It's fully functional but not yet notarized through Apple's Developer Program, so macOS will show a Gatekeeper warning on first launch. This is standard for open-source apps — Shotnix is safe and the source code is right here. Notarization is on the roadmap.
 >
 > To open: **Right-click → Open → Open** (macOS 13–14) or **System Settings → Privacy & Security → Open Anyway** (macOS 15+).
 

--- a/Sources/Shotnix/App/PreferencesWindowController.swift
+++ b/Sources/Shotnix/App/PreferencesWindowController.swift
@@ -92,7 +92,6 @@ struct GeneralSettingsView: View {
     @AppStorage("showMenuBarIcon") var showMenuBarIcon = true
     @AppStorage("hideDesktopIconsWhileCapturing") var hideDesktopIcons = false
     @AppStorage("afterCaptureShowOverlay") var showOverlay = true
-    @AppStorage("afterCaptureCopyToClipboard") var copyToClipboard = false
     @AppStorage("afterCaptureSaveAutomatically") var saveAutomatically = false
     @AppStorage("overlayOnLeft") var overlayOnLeft = false
     @AppStorage("overlayTimeout") var overlayTimeout: Double = 6.0
@@ -130,7 +129,6 @@ struct GeneralSettingsView: View {
             
             Section {
                 Toggle("Show Quick Access Overlay", isOn: $showOverlay)
-                Toggle("Copy file to clipboard", isOn: $copyToClipboard)
                 Toggle("Save automatically", isOn: $saveAutomatically)
                 
                 Picker("Overlay position", selection: $overlayOnLeft) {
@@ -202,6 +200,7 @@ struct ShortcutRow: View {
 struct ScreenshotsSettingsView: View {
     @AppStorage("screenshotFormat") var screenshotFormat = "png"
     @AppStorage("jpegQuality") var jpegQuality: Double = 0.95
+    @AppStorage("afterCaptureCopyToClipboard") var copyToClipboard = true
     @AppStorage("autoSaveLocation") var autoSaveLocation = ""
 
     var displayLocation: String {
@@ -231,6 +230,14 @@ struct ScreenshotsSettingsView: View {
                 }
             } header: {
                 Text("Export Format")
+            }
+
+            Section {
+                Toggle("Copy screenshots to clipboard", isOn: $copyToClipboard)
+            } header: {
+                Text("Clipboard")
+            } footer: {
+                Text("New screenshots are copied automatically. Turn this off if you only want to use the overlay or history actions.")
             }
 
             Section {
@@ -352,7 +359,7 @@ struct RecordingSettingsView: View {
 }
 
 struct AboutSettingsView: View {
-    let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.13.0-beta"
+    let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.14.0-beta"
     
     var body: some View {
         VStack(alignment: .center, spacing: 16) {
@@ -377,6 +384,10 @@ struct AboutSettingsView: View {
                 
                 ScrollView {
                     Text("""
+                    Version 0.14.0-beta
+                    • New screenshots copy to the clipboard by default
+                    • Added a Screenshots preference to disable automatic clipboard copying
+
                     Version 0.13.0-beta
                     • Redesigned Capture History with premium dark-glass styling
                     • More compact four-column capture cards with smoother preview framing

--- a/Sources/Shotnix/App/Settings.swift
+++ b/Sources/Shotnix/App/Settings.swift
@@ -71,7 +71,10 @@ enum Settings {
     }
 
     static var afterCaptureCopyToClipboard: Bool {
-        get { defaults.bool(forKey: "afterCaptureCopyToClipboard") }
+        get {
+            if defaults.object(forKey: "afterCaptureCopyToClipboard") == nil { return true }
+            return defaults.bool(forKey: "afterCaptureCopyToClipboard")
+        }
         set { defaults.set(newValue, forKey: "afterCaptureCopyToClipboard") }
     }
 


### PR DESCRIPTION
## Summary
- Copy new screenshots to the clipboard by default when no preference is set.
- Move the clipboard toggle into Preferences > Screenshots so users can disable automatic copying.
- Prepare local app metadata for v0.14.0-beta.

## Verification
- lsp_diagnostics clean for changed Swift files
- swift build
- bash build-app.sh
- codesign --verify --deep --strict
- Manual capture test: default unset preference copied image types to pasteboard
- Manual disabled test: false preference left pasteboard empty
- hdiutil verify Shotnix-v0.14.0-beta-macOS.dmg

## Notes
- swift test reports no Tests target in this package.