### PR TITLE
Prepare v0.14.1 beta notarized release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Copy this to .env.local for release builds. Do not commit .env.local.
+
+# Developer ID Application certificate name from Keychain.
+# Example: Developer ID Application: Your Name (TEAMID1234)
+SHOTNIX_CODESIGN_IDENTITY="Developer ID Application: Your Name (TEAMID1234)"
+
+# notarytool Keychain profile created with:
+# xcrun notarytool store-credentials "ShotnixNotaryProfile"
+SHOTNIX_NOTARY_PROFILE="ShotnixNotaryProfile"
+
+# Optional: override output DMG passed to notarize-dmg.sh.
+# SHOTNIX_DMG_PATH="/absolute/path/to/Shotnix-v0.14.1-macOS.dmg"

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,23 @@ DerivedData/
 *.zip
 dmg-background.png
 
+# Local signing/notarization config and secrets
+.env
+.env.*
+!.env.example
+*.p8
+*.p12
+*.cer
+*.certSigningRequest
+*.mobileprovision
+*.provisionprofile
+*.keychain
+*.keychain-db
+notary-log*.json
+notary-log*.plist
+
 # Claude
 .claude/
 CLAUDE.md
+RELEASE_GUIDE.md
 RELEASE_PLAN.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.14.1-beta] - 2026-05-14
+
+### Changed
+- **Overlay Save flow** — the quick-access Save action now writes directly to the configured Save Location and uses the same immediate confirmation flow as Copy.
+- **Record Window quality** — window recordings now use the sharper display-crop pipeline while targeting only the selected window.
+
 ## [0.14.0-beta] - 2026-05-12
 
 ### Changed

--- a/Info.plist
+++ b/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleDisplayName</key>
     <string>Shotnix</string>
     <key>CFBundleVersion</key>
-    <string>17</string>
+    <string>18</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.14.0</string>
+    <string>0.14.1</string>
     <key>CFBundleExecutable</key>
     <string>Shotnix</string>
     <key>CFBundlePackageType</key>

--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@
 ---
 
 > [!NOTE]
-> **Shotnix is in beta (v0.14.1-beta).** It's fully functional but not yet notarized through Apple's Developer Program, so macOS will show a Gatekeeper warning on first launch. This is standard for open-source apps — Shotnix is safe and the source code is right here. Notarization is on the roadmap.
->
-> To open: **Right-click → Open → Open** (macOS 13–14) or **System Settings → Privacy & Security → Open Anyway** (macOS 15+).
+> **Shotnix is in beta (v0.14.1-beta).** Official downloads are signed and notarized with Apple Developer ID. The source code is available here for review and local builds.
 
 <p align="center">
   <img src="assets/screenshots/shotnix-annotation-editor-demo.png" width="720" alt="Shotnix annotation editor demo" />
@@ -83,28 +81,6 @@ Visit **[shotnix.com](https://shotnix.com/)** for the latest download and projec
 2. Open the DMG and drag **Shotnix** to your Applications folder
 3. Grant **Screen Recording** permission when prompted
 
-> [!IMPORTANT]
-> **macOS will show a warning on first launch** — this is normal for open-source apps that aren't notarized through Apple's $99/year Developer Program. Shotnix is safe and fully open source. Here's how to open it:
->
-> **macOS Ventura & Sonoma (13–14):**
-> Right-click `Shotnix.app` → click **Open** → click **Open** again in the dialog
->
-> **macOS Sequoia (15+):**
-> 1. Try to open the app (it will be blocked)
-> 2. Go to **System Settings → Privacy & Security**
-> 3. Scroll down and click **Open Anyway** next to "Shotnix was blocked"
->
-> If macOS still blocks the app, use **System Settings → Privacy & Security → Open Anyway**.
->
-> **If macOS says "Shotnix" is damaged and can't be opened:**
-> This can happen because Shotnix is currently unsigned and macOS quarantines unsigned apps by default. After installing Shotnix, run this command in Terminal:
->
-> ```bash
-> xattr -rd com.apple.quarantine /Applications/Shotnix.app
-> ```
->
-> If the command is blocked, give Terminal Full Disk Access in **System Settings → Privacy & Security**, then run it again.
-
 ### Build from source
 
 ```bash
@@ -113,7 +89,7 @@ cd Shotnix
 bash build-app.sh
 ```
 
-This compiles a release build, assembles the app bundle, ad-hoc signs the binary, and copies `Shotnix.app` to `/Applications`.
+This compiles a release build, assembles the app bundle, signs the binary locally, and copies `Shotnix.app` to `/Applications`.
 
 **Requirements:** macOS 13+, Swift 5.9+
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ---
 
 > [!NOTE]
-> **Shotnix is in beta (v0.14.0-beta).** It's fully functional but not yet notarized through Apple's Developer Program, so macOS will show a Gatekeeper warning on first launch. This is standard for open-source apps — Shotnix is safe and the source code is right here. Notarization is on the roadmap.
+> **Shotnix is in beta (v0.14.1-beta).** It's fully functional but not yet notarized through Apple's Developer Program, so macOS will show a Gatekeeper warning on first launch. This is standard for open-source apps — Shotnix is safe and the source code is right here. Notarization is on the roadmap.
 >
 > To open: **Right-click → Open → Open** (macOS 13–14) or **System Settings → Privacy & Security → Open Anyway** (macOS 15+).
 

--- a/Sources/Shotnix/App/PreferencesWindowController.swift
+++ b/Sources/Shotnix/App/PreferencesWindowController.swift
@@ -359,7 +359,7 @@ struct RecordingSettingsView: View {
 }
 
 struct AboutSettingsView: View {
-    let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.14.0"
+    let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.14.1"
     
     var body: some View {
         VStack(alignment: .center, spacing: 16) {
@@ -384,6 +384,11 @@ struct AboutSettingsView: View {
                 
                 ScrollView {
                     Text("""
+                    Version 0.14.1
+                    • Overlay Save now writes to the configured Save Location immediately
+                    • Save uses the same quick confirmation experience as Copy
+                    • Record Window now captures the selected window more sharply
+
                     Version 0.14.0
                     • New screenshots copy to the clipboard by default
                     • Added a Screenshots preference to disable automatic clipboard copying

--- a/Sources/Shotnix/Capture/RecordingEngine.swift
+++ b/Sources/Shotnix/Capture/RecordingEngine.swift
@@ -230,8 +230,42 @@ final class RecordingEngine: NSObject {
                 excludingWindowNumbers: excludingWindowNumbers
             )
         case .window(let window, let screen):
-            return prepareWindowSource(window: window, on: screen, configuration: configuration)
+            return try await prepareWindowDisplaySource(
+                window: window,
+                on: screen,
+                configuration: configuration
+            )
         }
+    }
+
+    private func prepareWindowDisplaySource(
+        window: SCWindow,
+        on screen: NSScreen,
+        configuration: RecordingConfiguration
+    ) async throws -> PreparedCaptureSource {
+        let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
+        let selectedWindow = content.windows.first { $0.windowID == window.windowID } ?? window
+        let appKitRect = Self.appKitRect(fromScreenCaptureKitWindowFrame: selectedWindow.frame, on: screen)
+        guard let display = content.displays.first(where: { $0.frame.intersects(selectedWindow.frame) }) ?? content.displays.first else {
+            throw RecordingError.noDisplay
+        }
+
+        let filter = SCContentFilter(display: display, including: [selectedWindow])
+        return prepareDisplaySource(
+            rect: appKitRect,
+            on: screen,
+            configuration: configuration,
+            filter: filter
+        )
+    }
+
+    private static func appKitRect(fromScreenCaptureKitWindowFrame frame: CGRect, on screen: NSScreen) -> CGRect {
+        CGRect(
+            x: frame.minX,
+            y: screen.frame.origin.y + screen.frame.height - frame.maxY,
+            width: frame.width,
+            height: frame.height
+        )
     }
 
     private func prepareDisplaySource(
@@ -249,6 +283,20 @@ final class RecordingEngine: NSObject {
         }
 
         let filter = SCContentFilter(display: display, excludingWindows: excludedWindows)
+        return prepareDisplaySource(
+            rect: rect,
+            on: screen,
+            configuration: configuration,
+            filter: filter
+        )
+    }
+
+    private func prepareDisplaySource(
+        rect: CGRect,
+        on screen: NSScreen,
+        configuration: RecordingConfiguration,
+        filter: SCContentFilter
+    ) -> PreparedCaptureSource {
         let scale = Self.pixelScale(for: filter, fallbackScreen: screen)
         let originX = floor((rect.origin.x - screen.frame.origin.x) * scale) / scale
         let originY = floor((rect.origin.y - screen.frame.origin.y) * scale) / scale
@@ -267,15 +315,6 @@ final class RecordingEngine: NSObject {
         streamConfig.sourceRect = sourceRect
 
         return PreparedCaptureSource(filter: filter, streamConfig: streamConfig, pixelWidth: pixelWidth, pixelHeight: pixelHeight)
-    }
-
-    private func prepareWindowSource(window: SCWindow, on screen: NSScreen, configuration: RecordingConfiguration) -> PreparedCaptureSource {
-        let filter = SCContentFilter(desktopIndependentWindow: window)
-        let scale = Self.pixelScale(for: filter, fallbackScreen: screen)
-        let width = max(2, Self.evenCeil(Int(ceil(window.frame.width * scale))))
-        let height = max(2, Self.evenCeil(Int(ceil(window.frame.height * scale))))
-        let streamConfig = Self.streamConfiguration(width: width, height: height, configuration: configuration)
-        return PreparedCaptureSource(filter: filter, streamConfig: streamConfig, pixelWidth: width, pixelHeight: height)
     }
 
     private static func streamConfiguration(width: Int, height: Int, configuration: RecordingConfiguration) -> SCStreamConfiguration {
@@ -695,8 +734,7 @@ final class RecordingEngine: NSObject {
 
         var usesDisplayFilter: Bool {
             switch self {
-            case .displayRect: true
-            case .window: false
+            case .displayRect, .window: true
             }
         }
     }

--- a/Sources/Shotnix/Overlay/QuickAccessOverlay.swift
+++ b/Sources/Shotnix/Overlay/QuickAccessOverlay.swift
@@ -506,11 +506,17 @@ private final class QuickAccessWindow: NSWindow {
     }
 
     @objc private func saveAction() {
-        ImageExporter.saveWithPanel(image: image, suggestedName: ImageExporter.timestampedName) { [weak self] result in
-            if result.didSave {
-                self?.showConfirmation(icon: "arrow.down.circle") { [weak self] in self?.animatedClose() }
-            }
+        let dir = Settings.autoSaveLocation
+        let name = ImageExporter.timestampedName
+        let ext = Settings.screenshotFormat
+        let url = URL(fileURLWithPath: dir, isDirectory: true).appendingPathComponent("\(name).\(ext)")
+
+        guard ImageExporter.save(image: image, to: url) != nil else {
+            ToastWindow.show(message: "Could not save screenshot")
+            return
         }
+
+        showConfirmation(icon: "checkmark") { [weak self] in self?.animatedClose() }
     }
 
     /// Flash a confirmation icon over the thumbnail before closing

--- a/build-app.sh
+++ b/build-app.sh
@@ -5,7 +5,15 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 APP_NAME="Shotnix"
 APP_BUNDLE="$SCRIPT_DIR/$APP_NAME.app"
 ENTITLEMENTS="$SCRIPT_DIR/Shotnix.entitlements"
+
+if [ -f "$SCRIPT_DIR/.env.local" ]; then
+    set -a
+    source "$SCRIPT_DIR/.env.local"
+    set +a
+fi
+
 SIGN_IDENTITY="${SHOTNIX_CODESIGN_IDENTITY:-Shotnix Local Dev}"
+TIMESTAMP_MODE="${SHOTNIX_CODESIGN_TIMESTAMP:-auto}"
 
 echo "▶ Building $APP_NAME (release)…"
 cd "$SCRIPT_DIR"
@@ -35,10 +43,27 @@ if [ -f "$SCRIPT_DIR/PrivacyInfo.xcprivacy" ]; then
 fi
 
 echo "Signing with $SIGN_IDENTITY..."
-codesign --force --deep --sign "$SIGN_IDENTITY" \
-    --options runtime \
-    --entitlements "$ENTITLEMENTS" \
-    "$APP_BUNDLE"
+SIGN_ARGS=(--force --deep --sign "$SIGN_IDENTITY" --options runtime --entitlements "$ENTITLEMENTS")
+
+case "$TIMESTAMP_MODE" in
+    1|true|yes|on)
+        SIGN_ARGS+=(--timestamp)
+        ;;
+    0|false|no|off|none)
+        ;;
+    auto)
+        if [[ "$SIGN_IDENTITY" == Developer\ ID\ Application:* ]]; then
+            SIGN_ARGS+=(--timestamp)
+        fi
+        ;;
+    *)
+        echo "✗ Invalid SHOTNIX_CODESIGN_TIMESTAMP: $TIMESTAMP_MODE"
+        echo "  Use auto, true, or false."
+        exit 1
+        ;;
+esac
+
+codesign "${SIGN_ARGS[@]}" "$APP_BUNDLE"
 
 echo "▶ Copying to /Applications…"
 APPS_DEST="/Applications/$APP_NAME.app"

--- a/make-dmg.sh
+++ b/make-dmg.sh
@@ -8,6 +8,14 @@ VERSION=$(defaults read "$APP_PATH/Contents/Info.plist" CFBundleShortVersionStri
 DMG_NAME="$APP_NAME-v$VERSION-macOS"
 DMG_PATH="$SCRIPT_DIR/$DMG_NAME.dmg"
 
+if [ -f "$SCRIPT_DIR/.env.local" ]; then
+    set -a
+    source "$SCRIPT_DIR/.env.local"
+    set +a
+fi
+
+SIGN_IDENTITY="${SHOTNIX_CODESIGN_IDENTITY:-}"
+
 if [ ! -d "$APP_PATH" ]; then
     echo "Error: $APP_PATH not found. Run build-app.sh first."
     exit 1
@@ -44,6 +52,16 @@ fi
 
 create-dmg "${DMG_ARGS[@]}" "$DMG_PATH" "$APP_PATH"
 
+if [ -n "$SIGN_IDENTITY" ]; then
+    echo "▶ Signing DMG with $SIGN_IDENTITY…"
+    SIGN_ARGS=(--force --sign "$SIGN_IDENTITY")
+    if [[ "$SIGN_IDENTITY" == Developer\ ID\ Application:* ]]; then
+        SIGN_ARGS+=(--timestamp)
+    fi
+    codesign "${SIGN_ARGS[@]}" "$DMG_PATH"
+fi
+
 echo ""
 echo "✓ Done!  $DMG_NAME.dmg created."
 echo "  Upload this to your GitHub release."
+echo "  For Developer ID distribution, run: bash notarize-dmg.sh \"$DMG_PATH\""

--- a/notarize-dmg.sh
+++ b/notarize-dmg.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if [ -f "$SCRIPT_DIR/.env.local" ]; then
+    set -a
+    source "$SCRIPT_DIR/.env.local"
+    set +a
+fi
+
+DMG_PATH="${1:-${SHOTNIX_DMG_PATH:-}}"
+NOTARY_PROFILE="${SHOTNIX_NOTARY_PROFILE:-}"
+
+usage() {
+    cat <<'EOF'
+Usage: bash notarize-dmg.sh /path/to/Shotnix.dmg
+
+Required local setup, not committed to git:
+  1. Install your Developer ID Application certificate in Keychain.
+  2. Store notary credentials in Keychain:
+     xcrun notarytool store-credentials "ShotnixNotaryProfile"
+  3. Copy .env.example to .env.local and set:
+     SHOTNIX_NOTARY_PROFILE="ShotnixNotaryProfile"
+
+This script submits the DMG to Apple's notary service, waits, staples the
+ticket, then validates the result. It does not store Apple credentials.
+EOF
+}
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+    usage
+    exit 0
+fi
+
+if [ -z "$DMG_PATH" ]; then
+    usage
+    exit 1
+fi
+
+if [ ! -f "$DMG_PATH" ]; then
+    echo "✗ DMG not found: $DMG_PATH"
+    exit 1
+fi
+
+if [ -z "$NOTARY_PROFILE" ]; then
+    echo "✗ SHOTNIX_NOTARY_PROFILE is not set."
+    echo "  Copy .env.example to .env.local and set your Keychain profile name."
+    exit 1
+fi
+
+if ! command -v xcrun >/dev/null 2>&1; then
+    echo "✗ xcrun is required. Install Xcode command line tools first."
+    exit 1
+fi
+
+echo "▶ Submitting $DMG_PATH for notarization…"
+xcrun notarytool submit "$DMG_PATH" --keychain-profile "$NOTARY_PROFILE" --wait
+
+echo "▶ Stapling notarization ticket…"
+xcrun stapler staple "$DMG_PATH"
+
+echo "▶ Validating distribution…"
+if command -v syspolicy_check >/dev/null 2>&1; then
+    syspolicy_check distribution "$DMG_PATH"
+else
+    spctl -a -t open -vvv --context context:primary-signature "$DMG_PATH"
+fi
+
+echo "✓ Notarized, stapled, and validated: $DMG_PATH"


### PR DESCRIPTION
## Summary
- Prepare Shotnix v0.14.1 beta app metadata and direct-distribution release flow.
- Add public-safe Developer ID signing/notarization scripts while keeping Apple credentials local.
- Update README now that official downloads are signed and notarized.

## Verification
- `bash build-app.sh`
- `bash make-dmg.sh`
- `bash notarize-dmg.sh Shotnix-v0.14.1-macOS.dmg`
- `xcrun stapler validate Shotnix-v0.14.1-macOS.dmg`
- `spctl -a -t open -vvv --context context:primary-signature Shotnix-v0.14.1-macOS.dmg`
- `syspolicy_check distribution Shotnix-v0.14.1-macOS.dmg`

Co-authored-by: Codex <noreply@openai.com>